### PR TITLE
Enhance GitHub task details and completion workflow

### DIFF
--- a/components/TaskList.js
+++ b/components/TaskList.js
@@ -1,10 +1,13 @@
-﻿import { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 export default function TaskList() {
     const [tasks, setTasks] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [activeTaskId, setActiveTaskId] = useState(null);
+    const [completionNote, setCompletionNote] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState("");
 
-    // Fetch GitHub tasks
     useEffect(() => {
         const fetchTasks = async () => {
             try {
@@ -17,26 +20,60 @@ export default function TaskList() {
                 setLoading(false);
             }
         };
+
         fetchTasks();
     }, []);
 
-    // Complete a task
-    const completeTask = async (task) => {
+    const startCompletion = (taskId) => {
+        setActiveTaskId(taskId);
+        setCompletionNote("");
+        setError("");
+    };
+
+    const cancelCompletion = () => {
+        if (submitting) return;
+        setActiveTaskId(null);
+        setCompletionNote("");
+        setError("");
+    };
+
+    const completeTask = async (task, note) => {
+        const trimmedNote = note.trim();
+
+        if (!trimmedNote) {
+            setError("Please add a note about what was completed.");
+            return;
+        }
+
         try {
-            await fetch("/api/github", {
+            setSubmitting(true);
+            setError("");
+
+            const response = await fetch("/api/github", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     owner: task.repo.split("/")[0],
                     repo: task.repo.split("/")[1],
                     issue_number: task.issue_number,
+                    comment: trimmedNote,
                 }),
             });
 
-            // Remove from local list
-            setTasks(tasks.filter(t => t.id !== task.id));
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                const message = errorData?.error || "Failed to complete the task.";
+                throw new Error(message);
+            }
+
+            setTasks((prevTasks) => prevTasks.filter((t) => t.id !== task.id));
+            setActiveTaskId(null);
+            setCompletionNote("");
         } catch (err) {
             console.error("Error completing task:", err);
+            setError(err.message || "An unexpected error occurred.");
+        } finally {
+            setSubmitting(false);
         }
     };
 
@@ -44,31 +81,82 @@ export default function TaskList() {
     if (!tasks.length) return <p>No GitHub tasks assigned 🎉</p>;
 
     return (
-        <ul className="space-y-2">
-            {tasks.map(task => (
-                <li
-                    key={task.id}
-                    className="flex justify-between items-center border p-2 rounded shadow-sm"
-                >
-                    <div>
-                        <a
-                            href={task.url}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="font-medium text-blue-600 hover:underline"
-                        >
-                            {task.title}
-                        </a>
-                        <p className="text-xs text-gray-500">{task.repo}</p>
-                    </div>
-                    <button
-                        onClick={() => completeTask(task)}
-                        className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600"
-                    >
-                        ✓ Done
-                    </button>
-                </li>
-            ))}
+        <ul className="space-y-4">
+            {tasks.map((task) => {
+                const isActive = activeTaskId === task.id;
+
+                return (
+                    <li key={task.id} className="border p-3 rounded shadow-sm">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                            <div>
+                                <a
+                                    href={task.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="font-medium text-blue-600 hover:underline"
+                                >
+                                    {task.title}
+                                </a>
+                                <p className="text-xs text-gray-500">{task.repo}</p>
+                                {task.description ? (
+                                    <p className="text-sm text-gray-600 mt-2 whitespace-pre-wrap">
+                                        {task.description}
+                                    </p>
+                                ) : (
+                                    <p className="text-sm text-gray-400 mt-2 italic">
+                                        No description provided.
+                                    </p>
+                                )}
+                            </div>
+                            {!isActive && (
+                                <button
+                                    onClick={() => startCompletion(task.id)}
+                                    className="self-start bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600"
+                                >
+                                    ✓ Done
+                                </button>
+                            )}
+                        </div>
+
+                        {isActive && (
+                            <div className="mt-3 space-y-2">
+                                <label
+                                    htmlFor={`completion-note-${task.id}`}
+                                    className="text-sm font-medium text-gray-700"
+                                >
+                                    Add a note about what was completed
+                                </label>
+                                <textarea
+                                    id={`completion-note-${task.id}`}
+                                    className="w-full border rounded p-2 text-sm focus:outline-none focus:ring"
+                                    rows={4}
+                                    value={completionNote}
+                                    onChange={(event) => setCompletionNote(event.target.value)}
+                                    placeholder="Share what you completed before closing the issue..."
+                                    disabled={submitting}
+                                />
+                                {error && <p className="text-sm text-red-600">{error}</p>}
+                                <div className="flex gap-2">
+                                    <button
+                                        onClick={() => completeTask(task, completionNote)}
+                                        className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600 disabled:opacity-60"
+                                        disabled={submitting}
+                                    >
+                                        {submitting ? "Saving..." : "Submit & Close"}
+                                    </button>
+                                    <button
+                                        onClick={cancelCompletion}
+                                        className="bg-gray-200 text-gray-700 px-3 py-1 rounded hover:bg-gray-300 disabled:opacity-60"
+                                        disabled={submitting}
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </li>
+                );
+            })}
         </ul>
     );
 }

--- a/pages/api/github.js
+++ b/pages/api/github.js
@@ -20,6 +20,7 @@ export default async function handler(req, res) {
         url: issue.html_url,
         repo: issue.repository.full_name,
         issue_number: issue.number,
+        description: issue.body || "",
       }));
 
       return res.status(200).json(tasks);
@@ -31,7 +32,18 @@ export default async function handler(req, res) {
 
   if (req.method === "POST") {
     try {
-      const { owner, repo, issue_number } = req.body;
+      const { owner, repo, issue_number, comment } = req.body;
+
+      const trimmedComment = comment?.trim();
+
+      if (trimmedComment) {
+        await octokit.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number,
+          body: trimmedComment,
+        });
+      }
 
       await octokit.rest.issues.update({
         owner,


### PR DESCRIPTION
## Summary
- expose GitHub issue descriptions in the API response and surface them in the task list UI
- require a completion note before closing a task and show an inline form for capturing it
- post the completion note to GitHub before closing the related issue

## Testing
- npx next build *(fails: 403 Forbidden when downloading packages from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c879d9c3048331b3a01ec6aee910ba