### PR TITLE
Add Google Tasks integration and pipeline controls

### DIFF
--- a/components/TaskList.js
+++ b/components/TaskList.js
@@ -1,54 +1,152 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+const SOURCE_BADGE_CLASS = {
+  GitHub: "github",
+  "Google Tasks": "google",
+};
 
 export default function TaskList() {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState("");
   const [activeTaskId, setActiveTaskId] = useState(null);
   const [completionNote, setCompletionNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState("");
+  const [completionError, setCompletionError] = useState("");
+  const [pipelineStatus, setPipelineStatus] = useState({});
+
+  const loadTasks = useCallback(
+    async ({ silent = false, signal } = {}) => {
+      if (!silent) {
+        setLoading(true);
+        setFetchError("");
+      }
+
+      try {
+        const requests = [
+          fetch("/api/github", { signal }).then(async (response) => {
+            const data = await response.json().catch(() => null);
+
+            if (!response.ok) {
+              const error = new Error(data?.error || "Failed to load GitHub tasks.");
+              error.status = response.status;
+              throw error;
+            }
+
+            return Array.isArray(data) ? data : [];
+          }),
+          fetch("/api/google-tasks", { signal }).then(async (response) => {
+            const data = await response.json().catch(() => null);
+
+            if (!response.ok) {
+              const error = new Error(data?.error || "Failed to load Google Tasks.");
+              error.status = response.status;
+              throw error;
+            }
+
+            return Array.isArray(data) ? data : [];
+          }),
+        ];
+
+        const [githubResult, googleResult] = await Promise.allSettled(requests);
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        const combinedTasks = [];
+        const errors = [];
+
+        if (githubResult.status === "fulfilled") {
+          const githubTasks = githubResult.value.map((task) => ({
+            ...task,
+            id: task.id ?? `github-${task.issue_number}`,
+          }));
+          combinedTasks.push(...githubTasks);
+        } else {
+          errors.push("GitHub tasks");
+          console.error("Failed to load GitHub tasks:", githubResult.reason);
+        }
+
+        if (googleResult.status === "fulfilled") {
+          combinedTasks.push(...googleResult.value);
+        } else {
+          const isConfigError = googleResult.reason?.status === 503;
+          errors.push(isConfigError ? "Google Tasks (integration not configured)" : "Google Tasks");
+          console.error("Failed to load Google Tasks:", googleResult.reason);
+        }
+
+        setTasks(combinedTasks);
+
+        if (errors.length === 1) {
+          setFetchError(`Heads up: ${errors[0]} couldn't be loaded right now.`);
+        } else if (errors.length >= 2) {
+          setFetchError("We couldn't load your tasks right now. Please try again.");
+        } else {
+          setFetchError("");
+        }
+      } catch (error) {
+        if (error.name === "AbortError") {
+          return;
+        }
+
+        console.error("Error loading tasks:", error);
+        setTasks([]);
+        setFetchError("We couldn't load your tasks right now. Please try again.");
+      } finally {
+        if (!silent && !signal?.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    []
+  );
 
   useEffect(() => {
-    const fetchTasks = async () => {
-      try {
-        const response = await fetch("/api/github");
-        const data = await response.json();
-        setTasks(data);
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
+    const controller = new AbortController();
+
+    loadTasks({ signal: controller.signal });
+
+    return () => {
+      controller.abort();
     };
+  }, [loadTasks]);
 
-    fetchTasks();
-  }, []);
+  const startCompletion = (task) => {
+    if (!task || task.source !== "GitHub") {
+      return;
+    }
 
-  const startCompletion = (taskId) => {
-    setActiveTaskId(taskId);
+    setActiveTaskId(task.id);
     setCompletionNote("");
-    setError("");
+    setCompletionError("");
   };
 
   const cancelCompletion = () => {
-    if (submitting) return;
+    if (submitting) {
+      return;
+    }
 
     setActiveTaskId(null);
     setCompletionNote("");
-    setError("");
+    setCompletionError("");
   };
 
   const completeTask = async (task, note) => {
+    if (!task || task.source !== "GitHub") {
+      return;
+    }
+
     const trimmedNote = note.trim();
 
     if (!trimmedNote) {
-      setError("Please add a note about what was completed.");
+      setCompletionError("Please add a note about what was completed.");
       return;
     }
 
     try {
       setSubmitting(true);
-      setError("");
+      setCompletionError("");
 
       const response = await fetch("/api/github", {
         method: "POST",
@@ -61,9 +159,10 @@ export default function TaskList() {
         }),
       });
 
+      const responseData = await response.json().catch(() => null);
+
       if (!response.ok) {
-        const errorData = await response.json().catch(() => null);
-        const message = errorData?.error || "Failed to complete the task.";
+        const message = responseData?.error || "Failed to complete the task.";
         throw new Error(message);
       }
 
@@ -72,9 +171,80 @@ export default function TaskList() {
       setCompletionNote("");
     } catch (err) {
       console.error("Error completing task:", err);
-      setError(err.message || "An unexpected error occurred.");
+      setCompletionError(err.message || "An unexpected error occurred.");
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const updatePipeline = async (task, targetListId) => {
+    if (!task || task.source !== "Google Tasks") {
+      return;
+    }
+
+    if (!targetListId || targetListId === task.pipelineId) {
+      return;
+    }
+
+    setPipelineStatus((prev) => ({
+      ...prev,
+      [task.id]: { loading: true, error: "" },
+    }));
+
+    try {
+      const response = await fetch("/api/google-tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          taskId: task.googleTaskId,
+          currentListId: task.googleTaskListId,
+          targetListId,
+        }),
+      });
+
+      const responseData = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message = responseData?.error || "Failed to update the Google Task pipeline.";
+        throw new Error(message);
+      }
+
+      const newGoogleTaskId = responseData?.task?.id || task.googleTaskId;
+      const newTaskListId = responseData?.task?.tasklist || targetListId;
+      const nextPipeline = task.pipelineOptions?.find((option) => option.id === newTaskListId);
+      const pipelineName = nextPipeline?.name || task.pipelineName;
+
+      setTasks((prevTasks) =>
+        prevTasks.map((item) => {
+          if (item.id !== task.id) {
+            return item;
+          }
+
+          const nextId = `google-${newGoogleTaskId}`;
+
+          return {
+            ...item,
+            id: nextId,
+            googleTaskId: newGoogleTaskId,
+            googleTaskListId: newTaskListId,
+            pipelineId: newTaskListId,
+            pipelineName,
+            repo: pipelineName,
+          };
+        })
+      );
+
+      setPipelineStatus((prev) => {
+        const next = { ...prev };
+        delete next[task.id];
+        return next;
+      });
+    } catch (err) {
+      console.error("Failed to update Google Task pipeline:", err);
+      setPipelineStatus((prev) => ({
+        ...prev,
+        [task.id]: { loading: false, error: err.message || "Unable to update pipeline." },
+      }));
     }
   };
 
@@ -83,7 +253,7 @@ export default function TaskList() {
       <div className="task-card">
         <div className="task-state">
           <span className="task-state__spinner" aria-hidden="true" />
-          <p className="task-state__message">Loading your assigned issues…</p>
+          <p className="task-state__message">Loading your assigned tasks…</p>
         </div>
       </div>
     );
@@ -97,7 +267,8 @@ export default function TaskList() {
             🎉
           </span>
           <h2 className="task-state__title">You're all caught up!</h2>
-          <p className="task-state__message">No GitHub tasks assigned right now.</p>
+          <p className="task-state__message">No tasks need your attention right now.</p>
+          {fetchError && <p className="task-state__message task-state__message--muted">{fetchError}</p>}
         </div>
       </div>
     );
@@ -108,43 +279,76 @@ export default function TaskList() {
       <header className="task-card__header">
         <div>
           <span className="task-card__eyebrow">Assigned to you</span>
-          <h2 className="task-card__title">Stay on top of your GitHub issues</h2>
+          <h2 className="task-card__title">Stay on top of your workstreams</h2>
         </div>
         <p className="task-card__description">
-          Review each task, jot down a quick note about your progress, then mark it done without
-          ever leaving the hub.
+          Review GitHub issues, keep your Google Tasks organized, and check things off without
+          leaving your cockpit.
         </p>
       </header>
+
+      {fetchError && <p className="task-card__notice task-card__notice--warning">{fetchError}</p>}
 
       <ul className="task-card__items">
         {tasks.map((task) => {
           const isActive = activeTaskId === task.id;
           const description = task.description?.trim();
+          const badgeClass = SOURCE_BADGE_CLASS[task.source] || "default";
+          const pipelineState = pipelineStatus[task.id] || {};
 
           return (
             <li key={task.id} className={`task-item${isActive ? " task-item--active" : ""}`}>
               <div className="task-item__meta">
                 <div className="task-item__heading">
-                  <a
-                    href={task.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="task-item__title"
-                  >
-                    {task.title}
-                  </a>
-                  <p className="task-item__repo">{task.repo}</p>
+                  <div className="task-item__title-row">
+                    <a
+                      href={task.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="task-item__title"
+                    >
+                      {task.title}
+                    </a>
+                    {task.source && (
+                      <span className={`task-item__badge task-item__badge--${badgeClass}`}>
+                        {task.source}
+                      </span>
+                    )}
+                  </div>
+                  <p className="task-item__repo">
+                    {task.source === "GitHub" ? task.repo : `Pipeline: ${task.pipelineName}`}
+                  </p>
                 </div>
-                {!isActive && (
+                {task.source === "GitHub" && !isActive && (
                   <button
                     type="button"
-                    onClick={() => startCompletion(task.id)}
+                    onClick={() => startCompletion(task)}
                     className="button button--success"
                   >
                     Mark done
                   </button>
                 )}
               </div>
+
+              {task.source === "Google Tasks" && task.pipelineOptions?.length > 0 && (
+                <div className="task-item__pipeline">
+                  <label htmlFor={`pipeline-${task.id}`}>Pipeline</label>
+                  <select
+                    id={`pipeline-${task.id}`}
+                    className="task-item__pipeline-select"
+                    value={task.pipelineId}
+                    onChange={(event) => updatePipeline(task, event.target.value)}
+                    disabled={Boolean(pipelineState.loading)}
+                  >
+                    {task.pipelineOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.name}
+                      </option>
+                    ))}
+                  </select>
+                  {pipelineState.error && <p className="task-item__error">{pipelineState.error}</p>}
+                </div>
+              )}
 
               {description ? (
                 <p className="task-item__description">{description}</p>
@@ -154,7 +358,7 @@ export default function TaskList() {
                 </p>
               )}
 
-              {isActive && (
+              {isActive && task.source === "GitHub" && (
                 <div className="task-item__completion">
                   <label htmlFor={`completion-note-${task.id}`}>
                     Add a note about what was completed
@@ -168,7 +372,7 @@ export default function TaskList() {
                     placeholder="Share what you accomplished before closing the issue…"
                     disabled={submitting}
                   />
-                  {error && <p className="task-item__error">{error}</p>}
+                  {completionError && <p className="task-item__error">{completionError}</p>}
                   <div className="task-item__actions">
                     <button
                       type="button"

--- a/pages/api/github.js
+++ b/pages/api/github.js
@@ -13,8 +13,8 @@ export default async function handler(req, res) {
         per_page: 50, // adjust if you want more
       });
 
-      const tasks = data.map(issue => ({
-        id: issue.id,
+      const tasks = data.map((issue) => ({
+        id: `github-${issue.id}`,
         source: "GitHub",
         title: issue.title,
         url: issue.html_url,

--- a/pages/api/google-tasks.js
+++ b/pages/api/google-tasks.js
@@ -1,0 +1,310 @@
+const TASKS_BASE_URL = "https://tasks.googleapis.com/tasks/v1";
+const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+const MISSING_CREDENTIALS_ERROR = "MISSING_GOOGLE_TASKS_CREDENTIALS";
+
+function getConfiguredListIds() {
+  const raw = process.env.GOOGLE_TASKS_LIST_IDS;
+
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function getOAuthConfig() {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    const error = new Error(
+      "Google Tasks integration is not configured. Please provide GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REFRESH_TOKEN environment variables."
+    );
+    error.code = MISSING_CREDENTIALS_ERROR;
+    throw error;
+  }
+
+  return { clientId, clientSecret, refreshToken };
+}
+
+async function getAccessToken() {
+  const { clientId, clientSecret, refreshToken } = getOAuthConfig();
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    const message = data?.error_description || data?.error || "Failed to refresh Google access token.";
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+  const accessToken = data?.access_token;
+
+  if (!accessToken) {
+    throw new Error("Google access token response did not include an access_token.");
+  }
+
+  return accessToken;
+}
+
+async function fetchTaskLists(accessToken) {
+  const configuredIds = getConfiguredListIds();
+  const lists = [];
+  let pageToken;
+
+  do {
+    const url = new URL(`${TASKS_BASE_URL}/users/@me/lists`);
+    url.searchParams.set("maxResults", "100");
+    if (pageToken) {
+      url.searchParams.set("pageToken", pageToken);
+    }
+
+    const response = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      const message = data?.error?.message || "Failed to retrieve Google Task lists.";
+      throw new Error(message);
+    }
+
+    const data = await response.json();
+    if (Array.isArray(data.items)) {
+      lists.push(...data.items);
+    }
+    pageToken = data.nextPageToken;
+  } while (pageToken);
+
+  if (!configuredIds.length) {
+    return lists;
+  }
+
+  const listMap = new Map(lists.map((list) => [list.id, list]));
+  const filteredLists = configuredIds.map((id) => listMap.get(id)).filter(Boolean);
+
+  return filteredLists;
+}
+
+async function fetchTasksForList(accessToken, listId) {
+  const tasks = [];
+  let pageToken;
+
+  do {
+    const url = new URL(`${TASKS_BASE_URL}/lists/${encodeURIComponent(listId)}/tasks`);
+    url.searchParams.set("maxResults", "100");
+    url.searchParams.set("showCompleted", "false");
+    url.searchParams.set("showDeleted", "false");
+    url.searchParams.set("showHidden", "false");
+    if (pageToken) {
+      url.searchParams.set("pageToken", pageToken);
+    }
+
+    const response = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      const message = data?.error?.message || `Failed to retrieve tasks for Google Task list ${listId}.`;
+      throw new Error(message);
+    }
+
+    const data = await response.json();
+    if (Array.isArray(data.items)) {
+      tasks.push(...data.items);
+    }
+    pageToken = data.nextPageToken;
+  } while (pageToken);
+
+  return tasks;
+}
+
+function mapTaskToResponse(task, list, pipelineOptions) {
+  return {
+    id: `google-${task.id}`,
+    source: "Google Tasks",
+    title: task.title || "Untitled task",
+    url: `https://tasks.google.com/embed/list/${encodeURIComponent(list.id)}?task=${encodeURIComponent(task.id)}`,
+    repo: list.title,
+    description: task.notes || "",
+    pipelineId: list.id,
+    pipelineName: list.title,
+    pipelineOptions,
+    googleTaskId: task.id,
+    googleTaskListId: list.id,
+    status: task.status,
+    due: task.due || null,
+  };
+}
+
+function buildInsertPayload(task) {
+  const payload = {
+    title: task.title || "Untitled task",
+  };
+
+  if (task.notes) {
+    payload.notes = task.notes;
+  }
+
+  if (task.due) {
+    payload.due = task.due;
+  }
+
+  if (task.status) {
+    payload.status = task.status;
+  }
+
+  if (Array.isArray(task.links) && task.links.length) {
+    payload.links = task.links.map((link) => ({
+      description: link.description,
+      link: link.link,
+      type: link.type,
+    }));
+  }
+
+  return payload;
+}
+
+export default async function handler(req, res) {
+  if (req.method === "GET") {
+    try {
+      const accessToken = await getAccessToken();
+      const lists = await fetchTaskLists(accessToken);
+
+      if (!lists.length) {
+        return res.status(200).json([]);
+      }
+
+      const pipelineOptions = lists.map((list) => ({ id: list.id, name: list.title }));
+
+      const tasksByList = await Promise.all(
+        lists.map(async (list) => {
+          try {
+            const tasks = await fetchTasksForList(accessToken, list.id);
+            return tasks.map((task) => mapTaskToResponse(task, list, pipelineOptions));
+          } catch (error) {
+            console.error(`Failed to load Google Tasks for list ${list.id}:`, error);
+            return [];
+          }
+        })
+      );
+
+      const tasks = tasksByList.flat();
+
+      return res.status(200).json(tasks);
+    } catch (error) {
+      if (error.code === MISSING_CREDENTIALS_ERROR) {
+        return res.status(503).json({ error: error.message });
+      }
+
+      console.error("Google Tasks API error:", error);
+      return res.status(500).json({ error: error.message || "Failed to load Google Tasks." });
+    }
+  }
+
+  if (req.method === "POST") {
+    try {
+      const { taskId, currentListId, targetListId } = req.body || {};
+
+      if (!taskId || !currentListId || !targetListId) {
+        return res.status(400).json({ error: "taskId, currentListId, and targetListId are required." });
+      }
+
+      if (targetListId === currentListId) {
+        return res.status(200).json({
+          success: true,
+          task: { id: taskId, tasklist: currentListId },
+        });
+      }
+
+      const accessToken = await getAccessToken();
+
+      const currentTaskResponse = await fetch(
+        `${TASKS_BASE_URL}/lists/${encodeURIComponent(currentListId)}/tasks/${encodeURIComponent(taskId)}`,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      );
+
+      if (!currentTaskResponse.ok) {
+        const data = await currentTaskResponse.json().catch(() => null);
+        const message = data?.error?.message || "Unable to retrieve the Google Task to update.";
+        throw new Error(message);
+      }
+
+      const currentTask = await currentTaskResponse.json();
+      const insertPayload = buildInsertPayload(currentTask);
+
+      const insertResponse = await fetch(
+        `${TASKS_BASE_URL}/lists/${encodeURIComponent(targetListId)}/tasks`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(insertPayload),
+        }
+      );
+
+      if (!insertResponse.ok) {
+        const data = await insertResponse.json().catch(() => null);
+        const message = data?.error?.message || "Failed to move the Google Task to the selected pipeline.";
+        throw new Error(message);
+      }
+
+      const insertedTask = await insertResponse.json();
+
+      const deleteResponse = await fetch(
+        `${TASKS_BASE_URL}/lists/${encodeURIComponent(currentListId)}/tasks/${encodeURIComponent(taskId)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      );
+
+      if (!deleteResponse.ok) {
+        const data = await deleteResponse.json().catch(() => null);
+        const message = data?.error?.message || "The Google Task was moved but removing the original entry failed.";
+        throw new Error(message);
+      }
+
+      return res.status(200).json({
+        success: true,
+        task: {
+          id: insertedTask.id,
+          tasklist: targetListId,
+          status: insertedTask.status,
+        },
+      });
+    } catch (error) {
+      if (error.code === MISSING_CREDENTIALS_ERROR) {
+        return res.status(503).json({ error: error.message });
+      }
+
+      console.error("Error updating Google Task pipeline:", error);
+      return res.status(500).json({ error: error.message || "Failed to update Google Task." });
+    }
+  }
+
+  res.setHeader("Allow", ["GET", "POST"]);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,9 +8,9 @@ export default function Home() {
           <span className="hero__eyebrow">Focus. Finish. Ship.</span>
           <h1>My Task Hub</h1>
           <p>
-            A polished cockpit for your assigned GitHub issues. Scan what needs
-            attention, add a quick update, and close things out without jumping
-            between tabs.
+            A polished cockpit for your assigned GitHub issues and Google Tasks. Scan what
+            needs attention, reshuffle pipelines, add a quick update, and close things out
+            without jumping between tabs.
           </p>
         </header>
         <section className="task-section">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -153,6 +153,21 @@ main {
   max-width: 36rem;
 }
 
+.task-card__notice {
+  margin: 0 0 clamp(1rem, 2vw, 1.5rem) 0;
+  padding: 0.85rem 1.1rem;
+  border-radius: 16px;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  font-weight: 500;
+}
+
+.task-card__notice--warning {
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  color: #92400e;
+}
+
 .task-card__items {
   list-style: none;
   margin: 0;
@@ -200,6 +215,13 @@ main {
   gap: 0.2rem;
 }
 
+.task-item__title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+}
+
 .task-item__title {
   font-weight: 600;
   color: var(--slate-900);
@@ -216,6 +238,66 @@ main {
   margin: 0;
   font-size: 0.85rem;
   color: var(--slate-500);
+}
+
+.task-item__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.25rem 0.65rem;
+  text-transform: uppercase;
+}
+
+.task-item__badge--github {
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-strong);
+}
+
+.task-item__badge--google {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--success-strong);
+}
+
+.task-item__badge--default {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--slate-600);
+}
+
+.task-item__pipeline {
+  display: grid;
+  gap: 0.4rem;
+  margin-top: 0.85rem;
+}
+
+.task-item__pipeline label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--slate-600);
+}
+
+.task-item__pipeline-select {
+  border-radius: 12px;
+  border: 1px solid var(--border-strong);
+  padding: 0.55rem 0.8rem;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--slate-700);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-item__pipeline-select:focus {
+  outline: none;
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.task-item__pipeline-select:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
 }
 
 .task-item__description {
@@ -366,6 +448,10 @@ main {
   margin: 0;
   color: var(--slate-600);
   max-width: 26rem;
+}
+
+.task-state__message--muted {
+  color: var(--slate-500);
 }
 
 @keyframes spin {


### PR DESCRIPTION
## Summary
- add a Google Tasks API route that authenticates with OAuth refresh tokens, pulls list-based pipelines, and moves tasks between lists
- update the dashboard to merge GitHub issues with Google Tasks, surface source badges, and allow inline pipeline changes with error handling
- refresh the styling and copy to support the new workflows and prefix GitHub task ids for clarity

## Testing
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_e_68c9579d569c8331b95416031a003250