### PR TITLE
Use documented Fellow API key header

### DIFF
--- a/pages/api/fellow.js
+++ b/pages/api/fellow.js
@@ -316,6 +316,7 @@ function buildAuthHeaderOptions(token) {
     { Authorization: `Bearer ${trimmedToken}` },
     { Authorization: trimmedToken },
     { Authorization: `Token token=${trimmedToken}` },
+    { "X-API-KEY": trimmedToken },
     { "X-Api-Key": trimmedToken },
   ];
 


### PR DESCRIPTION
## Summary
- send the Fellow API token using the documented `X-API-KEY` header while retaining the camel-case fallback in the candidate list

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');

const source = fs
  .readFileSync('./pages/api/fellow.js', 'utf8')
  .replace('export default async function handler', 'async function handler')
  .concat('\nmodule.exports = { buildAuthHeaderOptions };');

const sandbox = {
  module: { exports: {} },
  exports: {},
  require,
  process,
  console,
  setTimeout,
  clearTimeout,
  setInterval,
  clearInterval,
};

vm.createContext(sandbox);
new vm.Script(source, { filename: 'fellow.js' }).runInContext(sandbox);

const { buildAuthHeaderOptions } = sandbox.module.exports;

const result = buildAuthHeaderOptions('test-token');
console.log(result);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d2e3e0d1e48331826486c22bf43b55