### PR TITLE
Handle Fellow API endpoint fallback

### DIFF
--- a/docs/fellow.md
+++ b/docs/fellow.md
@@ -14,3 +14,11 @@ The Fellow task sync relies on the following environment variables:
 > still read for backwards compatibility, but it is now treated as a base URL.
 > Please migrate to `FELLOW_API_BASE_URL` to avoid confusion and to take
 > advantage of the new REST endpoint support.
+
+The REST integration now attempts both the legacy `/api/v1/action-items`
+endpoint and the newer `/v1/action-items` route. When the configured base URL
+points to the web application host (for example `https://fellow.app`), the
+handler will automatically retry using the `https://api.fellow.app` domain. If
+you continue to see `404` responses from the Fellow API, explicitly set
+`FELLOW_API_BASE_URL=https://api.fellow.app` (or the equivalent API hostname
+provided by your Fellow workspace) to skip the fallback.


### PR DESCRIPTION
## Summary
- add fallback handling that tries the newer /v1 action item endpoint and API subdomain when calling the Fellow REST API
- expose the action item fetch helper and cover the new fallback logic with unit tests
- document the additional Fellow API routing behaviour and configuration guidance

## Testing
- node --test pages/api/__tests__/fellow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3ea31b2f483318941a57390108636