### PR TITLE
Add GraphQL fallback for Fellow action items

### DIFF
--- a/docs/fellow.md
+++ b/docs/fellow.md
@@ -16,9 +16,11 @@ The Fellow task sync relies on the following environment variables:
 > advantage of the new REST endpoint support.
 
 The REST integration now attempts both the legacy `/api/v1/action-items`
-endpoint and the newer `/v1/action-items` route. When the configured base URL
-points to the web application host (for example `https://fellow.app`), the
-handler will automatically retry using the `https://api.fellow.app` domain. If
-you continue to see `404` responses from the Fellow API, explicitly set
+endpoint, the newer `/v1/action-items` route, and their snake_case equivalents.
+When the configured base URL points to the web application host (for example
+`https://fellow.app`), the handler will automatically retry using the
+`https://api.fellow.app` domain. If all REST candidates return `404`, the
+integration falls back to the GraphQL endpoint (`/graphql`) using the same base
+URL. If you continue to see `404` responses from the Fellow API, explicitly set
 `FELLOW_API_BASE_URL=https://api.fellow.app` (or the equivalent API hostname
 provided by your Fellow workspace) to skip the fallback.

--- a/pages/api/__tests__/fellow.test.js
+++ b/pages/api/__tests__/fellow.test.js
@@ -71,14 +71,52 @@ test("dedupes duplicate REST containers and preserves stream context", () => {
   assert.equal(streamTask.url, "https://fellow.app/streams/roadmap");
 });
 
+test("maps GraphQL action items payload", () => {
+  const payload = {
+    viewer: {
+      assignedActionItems: {
+        edges: [
+          {
+            node: {
+              id: "g-1",
+              content: "Review draft",
+              description: "<p>Leave comments</p>",
+              dueDate: "2025-02-03",
+              status: "open",
+              url: "/action-items/g-1",
+              note: {
+                title: "Sprint Planning",
+                url: "/notes/sprint-planning",
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  const tasks = mapActionItemsToTasks(payload);
+
+  assert.equal(tasks.length, 1);
+  const [task] = tasks;
+
+  assert.equal(task.id, "fellow-g-1");
+  assert.equal(task.title, "Review draft");
+  assert.equal(task.description, "Leave comments");
+  assert.equal(task.dueDate, "2025-02-03");
+  assert.equal(task.status, "open");
+  assert.equal(task.repo, "Note: Sprint Planning");
+  assert.equal(task.url, "https://fellow.app/action-items/g-1");
+});
+
 test("fetchAssignedActionItems falls back to API subdomain and v1 route", async () => {
   const requests = [];
   const originalFetch = global.fetch;
 
-  global.fetch = async (url) => {
-    requests.push(url);
+  global.fetch = async (url, options = {}) => {
+    requests.push({ url, options });
 
-    if (requests.length < 4) {
+    if (requests.length <= 8) {
       return {
         ok: false,
         status: 404,
@@ -89,13 +127,28 @@ test("fetchAssignedActionItems falls back to API subdomain and v1 route", async 
     return {
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({ action_items: [] }),
+      text: async () =>
+        JSON.stringify({
+          data: {
+            viewer: {
+              assignedActionItems: {
+                edges: [],
+              },
+            },
+          },
+        }),
     };
   };
 
   try {
     const payload = await fetchAssignedActionItems("https://fellow.app", "test-token", 25);
-    assert.deepEqual(payload, { action_items: [] });
+    assert.deepEqual(payload, {
+      viewer: {
+        assignedActionItems: {
+          edges: [],
+        },
+      },
+    });
   } finally {
     if (originalFetch === undefined) {
       delete global.fetch;
@@ -104,13 +157,79 @@ test("fetchAssignedActionItems falls back to API subdomain and v1 route", async 
     }
   }
 
-  assert.equal(requests.length, 4);
-  assert.match(requests[0], /https:\/\/fellow\.app\/api\/v1\/action-items/);
-  assert.match(requests[1], /https:\/\/fellow\.app\/v1\/action-items/);
-  assert.match(requests[2], /https:\/\/api\.fellow\.app\/api\/v1\/action-items/);
-  assert.match(requests[3], /https:\/\/api\.fellow\.app\/v1\/action-items/);
+  assert.equal(requests.length, 9);
+  assert.match(requests[0].url, /https:\/\/fellow\.app\/api\/v1\/action-items/);
+  assert.match(requests[1].url, /https:\/\/fellow\.app\/v1\/action-items/);
+  assert.match(requests[2].url, /https:\/\/fellow\.app\/api\/v1\/action_items/);
+  assert.match(requests[3].url, /https:\/\/fellow\.app\/v1\/action_items/);
+  assert.match(requests[4].url, /https:\/\/api\.fellow\.app\/api\/v1\/action-items/);
+  assert.match(requests[5].url, /https:\/\/api\.fellow\.app\/v1\/action-items/);
+  assert.match(requests[6].url, /https:\/\/api\.fellow\.app\/api\/v1\/action_items/);
+  assert.match(requests[7].url, /https:\/\/api\.fellow\.app\/v1\/action_items/);
 
-  const finalUrl = new URL(requests[requests.length - 1]);
-  assert.equal(finalUrl.searchParams.get("assigned_to"), "me");
-  assert.equal(finalUrl.searchParams.get("limit"), "25");
+  const lastRestUrl = new URL(requests[7].url);
+  assert.equal(lastRestUrl.searchParams.get("assigned_to"), "me");
+  assert.equal(lastRestUrl.searchParams.get("limit"), "25");
+
+  assert.equal(requests[requests.length - 1].options.method, "POST");
+  const body = JSON.parse(requests[requests.length - 1].options.body);
+  assert.equal(body.variables.first, 25);
+  assert(body.query.includes("assignedActionItems"));
+});
+
+test("fetchAssignedActionItems returns GraphQL payload when REST endpoints missing", async () => {
+  const calls = [];
+  const originalFetch = global.fetch;
+
+  global.fetch = async (url, options = {}) => {
+    calls.push({ url, options });
+
+    if (options.method === "GET" || !options.method) {
+      return {
+        ok: false,
+        status: 404,
+        text: async () => JSON.stringify({ message: "Not found" }),
+      };
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          data: {
+            viewer: {
+              assignedActionItems: {
+                edges: [
+                  {
+                    node: {
+                      id: "graphql-1",
+                      content: "GraphQL task",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }),
+    };
+  };
+
+  try {
+    const payload = await fetchAssignedActionItems("https://fellow.app", "test-token", 5);
+    assert.equal(
+      payload.viewer.assignedActionItems.edges[0].node.id,
+      "graphql-1"
+    );
+  } finally {
+    if (originalFetch === undefined) {
+      delete global.fetch;
+    } else {
+      global.fetch = originalFetch;
+    }
+  }
+
+  assert.equal(calls.length, 9);
+  assert.match(calls[8].url, /\/graphql$/);
+  assert.equal(calls[8].options.method, "POST");
 });


### PR DESCRIPTION
## Summary
- add a GraphQL fallback when the Fellow REST action item endpoints return 404s and expand candidate paths to cover snake_case routes
- improve context resolution so note metadata is surfaced in task labels
- update documentation and tests to cover the new fallback behaviour

## Testing
- node --test pages/api/__tests__/fellow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d45055d2908331b0bf939fb21d813a