### PR TITLE
Use Fellow notes endpoint for action items

### DIFF
--- a/docs/fellow.md
+++ b/docs/fellow.md
@@ -15,12 +15,12 @@ The Fellow task sync relies on the following environment variables:
 > Please migrate to `FELLOW_API_BASE_URL` to avoid confusion and to take
 > advantage of the new REST endpoint support.
 
-The REST integration now attempts both the legacy `/api/v1/action-items`
-endpoint, the newer `/v1/action-items` route, and their snake_case equivalents.
-When the configured base URL points to the web application host (for example
-`https://fellow.app`), the handler will automatically retry using the
-`https://api.fellow.app` domain. If all REST candidates return `404`, the
-integration falls back to the GraphQL endpoint (`/graphql`) using the same base
-URL. If you continue to see `404` responses from the Fellow API, explicitly set
-`FELLOW_API_BASE_URL=https://api.fellow.app` (or the equivalent API hostname
-provided by your Fellow workspace) to skip the fallback.
+The REST integration now targets the notes listing endpoint
+(`/apps/api/v1/notes/list`) to retrieve assigned action items. The handler
+tries multiple path variations (for example `/api/v1/notes/list`) and will also
+retry against the `https://api.fellow.app` subdomain when the configured base
+URL points to the main web application host. If all REST candidates return
+`404`, the integration falls back to the GraphQL endpoint (`/graphql`) using
+the same base URL. If you continue to see `404` responses from the Fellow API,
+explicitly set `FELLOW_API_BASE_URL=https://api.fellow.app` (or the equivalent
+API hostname provided by your Fellow workspace) to skip the fallback.


### PR DESCRIPTION
## Summary
- switch the REST integration to query the Fellow notes listing endpoint and reuse the new request payload across fallback hosts
- enrich action items with note context while walking REST payloads so downstream mapping preserves meeting/stream data
- update the Fellow integration tests and docs to reflect the new endpoint strategy

## Testing
- node --test pages/api/__tests__/fellow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d4589cbd388331ae00b794dc18fe69