### PR TITLE
Fix Trello API base path handling

### DIFF
--- a/pages/api/__tests__/trello.test.js
+++ b/pages/api/__tests__/trello.test.js
@@ -54,10 +54,19 @@ test("filters cards by configured board IDs", async () => {
 });
 
 test("ensureBaseUrl normalizes Trello endpoints", async () => {
-  const { ensureBaseUrl } = await import("../trello.js");
+  const { ensureBaseUrl, buildUrl } = await import("../trello.js");
 
   assert.equal(ensureBaseUrl("api.trello.com/1"), "https://api.trello.com/1");
   assert.equal(ensureBaseUrl("https://api.trello.com/1/"), "https://api.trello.com/1");
+
+  assert.equal(
+    buildUrl("https://api.trello.com/1", "/members/test/cards"),
+    "https://api.trello.com/1/members/test/cards"
+  );
+  assert.equal(
+    buildUrl("https://api.trello.com/1/", "members/test/cards"),
+    "https://api.trello.com/1/members/test/cards"
+  );
 });
 
 test("fetchMemberCards requests open cards with board and list context", async () => {
@@ -90,7 +99,7 @@ test("fetchMemberCards requests open cards with board and list context", async (
   const request = requests[0];
   const params = request.url.searchParams;
 
-  assert.equal(request.url.pathname, "/members/member/cards");
+  assert.equal(request.url.pathname, "/1/members/member/cards");
   assert.equal(params.get("key"), "key");
   assert.equal(params.get("token"), "token");
   assert.equal(params.get("filter"), "open");

--- a/pages/api/trello.js
+++ b/pages/api/trello.js
@@ -38,14 +38,14 @@ function buildUrl(baseUrl, path) {
     return normalizedBase;
   }
 
-  try {
-    const baseForUrl = normalizedBase.endsWith("/") ? normalizedBase : `${normalizedBase}/`;
-    return new URL(path, baseForUrl).toString();
-  } catch (error) {
-    const trimmedBase = normalizedBase.replace(/\/+$/, "");
-    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-    return `${trimmedBase}${normalizedPath}`;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(path)) {
+    return path;
   }
+
+  const trimmedBase = normalizedBase.replace(/\/+$/, "");
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  return `${trimmedBase}${normalizedPath}`;
 }
 
 function getBaseUrl() {
@@ -195,7 +195,7 @@ function filterCardsByBoard(cards, boardIds) {
 }
 
 async function fetchMemberCards(baseUrl, key, token, memberId, limit) {
-  const url = new URL(buildUrl(baseUrl, `/members/${encodeURIComponent(memberId)}/cards`));
+  const url = new URL(buildUrl(baseUrl, `members/${encodeURIComponent(memberId)}/cards`));
   url.searchParams.set("key", key);
   url.searchParams.set("token", token);
   url.searchParams.set("filter", "open");
@@ -290,4 +290,5 @@ export {
   filterCardsByBoard,
   fetchMemberCards,
   ensureBaseUrl,
+  buildUrl,
 };


### PR DESCRIPTION
## Summary
- ensure the Trello API URL builder preserves the `/1` path segment and exposes the helper for testing
- adjust member card fetching to avoid dropping the API version prefix
- expand Trello API tests to cover the corrected URL building behavior

## Testing
- node --test pages/api/__tests__/trello.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5a92c9cd48331a8b7f869fda7c2e2