### PR TITLE
Add Trello card list management and comments

### DIFF
--- a/pages/api/__tests__/trello.test.js
+++ b/pages/api/__tests__/trello.test.js
@@ -20,7 +20,18 @@ test("maps Trello cards into task objects", async () => {
     },
   ];
 
-  const tasks = mapCardsToTasks(cards);
+  const boardLists = new Map([
+    [
+      "board-1",
+      [
+        { id: "list-1", name: "Backlog" },
+        { id: "list-2", name: "In Progress" },
+        { id: "list-3", name: "Review" },
+      ],
+    ],
+  ]);
+
+  const tasks = mapCardsToTasks(cards, boardLists);
 
   assert.equal(tasks.length, 1);
   const [task] = tasks;
@@ -34,6 +45,11 @@ test("maps Trello cards into task objects", async () => {
   assert.equal(task.url, "https://trello.com/c/abc123");
   assert.equal(task.dueDate, "2025-05-01T10:00:00.000Z");
   assert.equal(task.status, "");
+  assert.deepEqual(task.pipelineOptions, [
+    { id: "list-1", name: "Backlog" },
+    { id: "list-2", name: "In Progress" },
+    { id: "list-3", name: "Review" },
+  ]);
 });
 
 test("filters cards by configured board IDs", async () => {
@@ -110,4 +126,128 @@ test("fetchMemberCards requests open cards with board and list context", async (
   assert.equal(params.get("list_fields"), "name");
   assert.equal(params.get("limit"), "25");
   assert.equal(request.options.headers.Accept, "application/json");
+});
+
+test("fetchBoardLists requests lists for the given board", async () => {
+  const { fetchBoardLists } = await import("../trello.js");
+
+  const requests = [];
+  const originalFetch = global.fetch;
+
+  global.fetch = async (url, options = {}) => {
+    requests.push({ url: new URL(url), options });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => [
+        { id: "list-1", name: "Backlog" },
+        { id: "list-2", name: "In Progress" },
+      ],
+    };
+  };
+
+  try {
+    const lists = await fetchBoardLists("https://api.trello.com/1", "key", "token", "board-123");
+    assert.equal(lists.length, 2);
+  } finally {
+    if (originalFetch === undefined) {
+      delete global.fetch;
+    } else {
+      global.fetch = originalFetch;
+    }
+  }
+
+  assert.equal(requests.length, 1);
+  const request = requests[0];
+  const params = request.url.searchParams;
+
+  assert.equal(request.url.pathname, "/1/boards/board-123/lists");
+  assert.equal(params.get("key"), "key");
+  assert.equal(params.get("token"), "token");
+  assert.equal(params.get("filter"), "open");
+  assert.equal(params.get("fields"), "name");
+  assert.equal(request.options.headers.Accept, "application/json");
+});
+
+test("moveCardToList updates the Trello list", async () => {
+  const { moveCardToList } = await import("../trello.js");
+
+  const requests = [];
+  const originalFetch = global.fetch;
+
+  global.fetch = async (url, options = {}) => {
+    requests.push({ url: new URL(url), options });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "card-123", idList: "list-2" }),
+    };
+  };
+
+  try {
+    const response = await moveCardToList("https://api.trello.com/1", "key", "token", "card-123", "list-2");
+    assert.equal(response.idList, "list-2");
+  } finally {
+    if (originalFetch === undefined) {
+      delete global.fetch;
+    } else {
+      global.fetch = originalFetch;
+    }
+  }
+
+  assert.equal(requests.length, 1);
+  const request = requests[0];
+  const params = request.url.searchParams;
+
+  assert.equal(request.url.pathname, "/1/cards/card-123/idList");
+  assert.equal(request.options.method, "PUT");
+  assert.equal(params.get("value"), "list-2");
+  assert.equal(params.get("key"), "key");
+  assert.equal(params.get("token"), "token");
+});
+
+test("addCommentToCard posts comments to Trello", async () => {
+  const { addCommentToCard } = await import("../trello.js");
+
+  const requests = [];
+  const originalFetch = global.fetch;
+
+  global.fetch = async (url, options = {}) => {
+    requests.push({ url: new URL(url), options });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "comment-1" }),
+    };
+  };
+
+  try {
+    const response = await addCommentToCard(
+      "https://api.trello.com/1",
+      "key",
+      "token",
+      "card-123",
+      "This needs attention"
+    );
+    assert.equal(response.id, "comment-1");
+  } finally {
+    if (originalFetch === undefined) {
+      delete global.fetch;
+    } else {
+      global.fetch = originalFetch;
+    }
+  }
+
+  assert.equal(requests.length, 1);
+  const request = requests[0];
+  const params = request.url.searchParams;
+
+  assert.equal(request.url.pathname, "/1/cards/card-123/actions/comments");
+  assert.equal(request.options.method, "POST");
+  assert.equal(params.get("key"), "key");
+  assert.equal(params.get("token"), "token");
+  assert.equal(request.options.headers["Content-Type"], "application/x-www-form-urlencoded");
+
+  const body = request.options.body;
+  assert.equal(body.get("text"), "This needs attention");
 });

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -364,6 +364,13 @@ main {
   font-weight: 500;
 }
 
+.task-item__success {
+  margin: 0.5rem 0 0 0;
+  color: var(--success-strong);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
 .task-item__actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- surface Trello board list options when loading cards and allow updating their lists via the API
- add Trello card commenting support in the API and expose a UI for editing lists and posting comments
- style success feedback and extend Trello API unit tests to cover the new helpers

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d5acd105088331b7233d13a4960c5b