### PR TITLE
Add Fellow board Trello integration

### DIFF
--- a/docs/trello.md
+++ b/docs/trello.md
@@ -8,6 +8,10 @@ The Trello sync relies on the following environment variables:
   assigned cards will be fetched.
 - `TRELLO_BOARD_IDS` – optional comma-separated list of Trello board IDs to include. When unset all
   open cards assigned to the configured member are returned.
+- `TRELLO_EXCLUDED_BOARD_IDS` – optional comma-separated list of board IDs to ignore. These boards
+  are filtered out even when they appear in the allow list above or when no allow list is provided.
+- `TRELLO_FELLOW_BOARD_IDS` – optional comma-separated list of board IDs that should power the
+  Fellow-specific task feed.
 - `TRELLO_API_BASE_URL` – optional base URL for the Trello API. Defaults to
   `https://api.trello.com/1` when unset.
 - `TRELLO_CARD_LIMIT` – optional cap for the number of cards fetched per request (defaults to `200`).
@@ -20,3 +24,14 @@ custom integrations.
 > **Tip:** You can find a board's ID by opening the board in Trello, choosing **More** → **Link to
 > this board**, and copying the identifier from the generated URL (the part between `/b/` and the
 > board slug).
+
+## Fellow board setup
+
+Add the board ID of your dedicated Fellow workspace board to `TRELLO_FELLOW_BOARD_IDS`. Multiple
+boards can be supported by providing a comma-separated list. The `/api/trello-fellow` endpoint will
+only surface cards from these boards and will relabel them with the `Fellow` source badge while still
+exposing the Trello metadata (`trelloCardId`, list information, etc.).
+
+If there are Trello boards you never want to see in either feed, list them in
+`TRELLO_EXCLUDED_BOARD_IDS`. Cards from excluded boards are ignored even when the board ID appears in
+`TRELLO_BOARD_IDS` or `TRELLO_FELLOW_BOARD_IDS`.

--- a/pages/api/trello-fellow.js
+++ b/pages/api/trello-fellow.js
@@ -1,0 +1,90 @@
+import {
+  mapCardsToTasks,
+  filterCardsByBoard,
+  fetchMemberCards,
+  fetchBoardLists,
+  getConfiguredFellowBoardIds,
+  getExcludedBoardIds,
+  getCardLimit,
+  getBaseUrl,
+  ensureConfiguredAuth,
+  ensureConfiguredMemberId,
+} from "./trello";
+
+const MISSING_CREDENTIALS_ERROR = "MISSING_TRELLO_CREDENTIALS";
+
+export async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const fellowBoardIds = getConfiguredFellowBoardIds();
+
+    if (fellowBoardIds.length === 0) {
+      return res.status(200).json([]);
+    }
+
+    const { key, token } = ensureConfiguredAuth();
+    const memberId = ensureConfiguredMemberId();
+    const baseUrl = getBaseUrl();
+    const limit = getCardLimit();
+    const excludedBoardIds = getExcludedBoardIds();
+
+    const cards = await fetchMemberCards(baseUrl, key, token, memberId, limit);
+    const filteredCards = filterCardsByBoard(cards, fellowBoardIds, excludedBoardIds);
+
+    const boardIdSet = new Set();
+    for (const card of filteredCards) {
+      const boardId = typeof card?.idBoard === "string" ? card.idBoard.trim() : "";
+      if (boardId) {
+        boardIdSet.add(boardId);
+      }
+    }
+
+    const boardListEntries = await Promise.all(
+      Array.from(boardIdSet).map(async (boardId) => {
+        try {
+          const lists = await fetchBoardLists(baseUrl, key, token, boardId);
+          return [boardId, lists];
+        } catch (error) {
+          console.error(`Failed to load Trello lists for board ${boardId}:`, error);
+          return [boardId, []];
+        }
+      })
+    );
+
+    const boardLists = new Map(boardListEntries);
+    const tasks = mapCardsToTasks(filteredCards, boardLists).map((task) => ({
+      ...task,
+      source: "Fellow",
+    }));
+
+    return res.status(200).json(tasks);
+  } catch (error) {
+    if (error.code === MISSING_CREDENTIALS_ERROR) {
+      return res.status(503).json({ error: error.message });
+    }
+
+    const status = Number.isInteger(error.status) ? error.status : null;
+
+    if (status === 401 || status === 403) {
+      console.error("Trello API authentication error:", error);
+      return res.status(503).json({
+        error:
+          "Trello integration authentication failed. Please verify the configured TRELLO_API_KEY, TRELLO_TOKEN, and TRELLO_MEMBER_ID.",
+      });
+    }
+
+    if (status && status >= 400 && status < 600) {
+      console.error("Trello API error:", error);
+      return res.status(status).json({ error: error.message || "Failed to load Trello cards." });
+    }
+
+    console.error("Trello API error:", error);
+    return res.status(500).json({ error: error.message || "Failed to load Trello cards." });
+  }
+}
+
+export default handler;


### PR DESCRIPTION
## Summary
- add shared Trello helpers for board allow/exclude lists
- introduce a Fellow-specific Trello API endpoint and surface the results in the task list UI
- document the new environment variables for configuring excluded and Fellow boards

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d6ba35b2988331b936e7007803fce0