### PR TITLE
Label Trello Fellow board cards as Fellow

### DIFF
--- a/docs/trello.md
+++ b/docs/trello.md
@@ -8,6 +8,8 @@ The Trello sync relies on the following environment variables:
   assigned cards will be fetched.
 - `TRELLO_BOARD_IDS` – optional comma-separated list of Trello board IDs to include. When unset all
   open cards assigned to the configured member are returned.
+- `TRELLO_FELLOW_BOARD_ID` – optional Trello board ID whose cards should be labeled "Fellow" in the
+  UI instead of "Trello".
 - `TRELLO_API_BASE_URL` – optional base URL for the Trello API. Defaults to
   `https://api.trello.com/1` when unset.
 - `TRELLO_CARD_LIMIT` – optional cap for the number of cards fetched per request (defaults to `200`).

--- a/pages/api/__tests__/trello.test.js
+++ b/pages/api/__tests__/trello.test.js
@@ -37,6 +37,7 @@ test("maps Trello cards into task objects", async () => {
   const [task] = tasks;
 
   assert.equal(task.id, "trello-abc123");
+  assert.equal(task.source, "Trello");
   assert.equal(task.title, "Update onboarding docs");
   assert.equal(task.description, "Ensure the getting started guide references the latest tooling.");
   assert.equal(task.repo, "Board: Product Ops");
@@ -50,6 +51,35 @@ test("maps Trello cards into task objects", async () => {
     { id: "list-2", name: "In Progress" },
     { id: "list-3", name: "Review" },
   ]);
+});
+
+test("maps cards from the fellow board with a Fellow source label", async () => {
+  const originalValue = process.env.TRELLO_FELLOW_BOARD_ID;
+  process.env.TRELLO_FELLOW_BOARD_ID = "fellow-board";
+
+  try {
+    const { mapCardsToTasks } = await import("../trello.js?fellow");
+
+    const cards = [
+      {
+        id: "fellow-1",
+        name: "Prep mentorship notes",
+        idBoard: "fellow-board",
+        idList: "list-1",
+      },
+    ];
+
+    const tasks = mapCardsToTasks(cards, new Map());
+
+    assert.equal(tasks.length, 1);
+    assert.equal(tasks[0].source, "Fellow");
+  } finally {
+    if (originalValue === undefined) {
+      delete process.env.TRELLO_FELLOW_BOARD_ID;
+    } else {
+      process.env.TRELLO_FELLOW_BOARD_ID = originalValue;
+    }
+  }
 });
 
 test("filters cards by configured board IDs", async () => {

--- a/pages/api/trello.js
+++ b/pages/api/trello.js
@@ -154,6 +154,16 @@ function mapListsToOptions(lists) {
   return options;
 }
 
+function getBoardSource(boardId) {
+  const fellowBoardId = process.env.TRELLO_FELLOW_BOARD_ID?.trim();
+
+  if (fellowBoardId && boardId === fellowBoardId) {
+    return "Fellow";
+  }
+
+  return "Trello";
+}
+
 function mapCardsToTasks(cards, boardLists = new Map()) {
   if (!Array.isArray(cards)) {
     return [];
@@ -192,10 +202,11 @@ function mapCardsToTasks(cards, boardLists = new Map()) {
     const pipelineOptions = boardId
       ? mapListsToOptions(boardLists.get(boardId))
       : [];
+    const source = getBoardSource(boardId);
 
     tasks.push({
       id: `trello-${id}`,
-      source: "Trello",
+      source,
       title,
       description,
       url: normalizeCardUrl(card),


### PR DESCRIPTION
## Summary
- add a board-source helper that renames the configured Fellow board to "Fellow"
- document the new `TRELLO_FELLOW_BOARD_ID` environment variable for configuration
- extend the Trello mapper tests to cover the Fellow board label

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d6c3001e048331a1b5fdecc4a79b4b