### PR TITLE
Create multi-page layout with dashboard and Kanban board

### DIFF
--- a/components/KanbanBoard.js
+++ b/components/KanbanBoard.js
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTasks } from "../hooks/useTasks";
+
+const STAGES = ["Backlog", "In Progress", "Review", "Done"];
+
+function deriveInitialStage(task) {
+  const statusText = [task?.status, task?.pipelineName, task?.state]
+    .filter(Boolean)
+    .map((value) => value.toString().toLowerCase())
+    .join(" ");
+
+  if (statusText.includes("review")) {
+    return "Review";
+  }
+
+  if (statusText.includes("progress") || statusText.includes("doing") || statusText.includes("active")) {
+    return "In Progress";
+  }
+
+  if (
+    statusText.includes("done") ||
+    statusText.includes("complete") ||
+    statusText.includes("closed") ||
+    statusText.includes("resolved")
+  ) {
+    return "Done";
+  }
+
+  return "Backlog";
+}
+
+function getSourceKey(task) {
+  return task?.source || "Other";
+}
+
+export default function KanbanBoard() {
+  const { tasks, loading, fetchError } = useTasks();
+  const [taskStages, setTaskStages] = useState({});
+  const [visibleSources, setVisibleSources] = useState({});
+
+  useEffect(() => {
+    setTaskStages((prev) => {
+      const next = { ...prev };
+      tasks.forEach((task) => {
+        if (!next[task.id]) {
+          next[task.id] = deriveInitialStage(task);
+        }
+      });
+      return next;
+    });
+  }, [tasks]);
+
+  useEffect(() => {
+    setVisibleSources((prev) => {
+      const next = { ...prev };
+      tasks.forEach((task) => {
+        const source = getSourceKey(task);
+        if (typeof next[source] === "undefined") {
+          next[source] = true;
+        }
+      });
+      return next;
+    });
+  }, [tasks]);
+
+  const columns = useMemo(() => {
+    const grouped = Object.fromEntries(STAGES.map((stage) => [stage, []]));
+
+    tasks.forEach((task) => {
+      const source = getSourceKey(task);
+      if (!visibleSources[source]) {
+        return;
+      }
+
+      const stage = taskStages[task.id] || "Backlog";
+      if (!grouped[stage]) {
+        grouped[stage] = [];
+      }
+
+      grouped[stage].push(task);
+    });
+
+    return grouped;
+  }, [taskStages, tasks, visibleSources]);
+
+  const toggleSource = (source) => {
+    setVisibleSources((prev) => ({
+      ...prev,
+      [source]: !prev[source],
+    }));
+  };
+
+  const handleStageChange = (taskId, stage) => {
+    setTaskStages((prev) => ({
+      ...prev,
+      [taskId]: stage,
+    }));
+  };
+
+  if (loading) {
+    return (
+      <div className="kanban-board kanban-board--loading">
+        <p>Loading board…</p>
+      </div>
+    );
+  }
+
+  if (!tasks.length) {
+    return (
+      <div className="kanban-board kanban-board--empty">
+        <p>You&apos;re all caught up! No tasks to show right now.</p>
+      </div>
+    );
+  }
+
+  const sources = Object.keys(visibleSources);
+
+  return (
+    <div className="kanban-board">
+      <div className="kanban-board__controls" aria-label="Task source filters">
+        <span className="kanban-board__filters-label">Task sources:</span>
+        <div className="kanban-board__filters">
+          {sources.map((source) => (
+            <button
+              key={source}
+              type="button"
+              className={`kanban-board__filter${visibleSources[source] ? " kanban-board__filter--active" : ""}`}
+              onClick={() => toggleSource(source)}
+              aria-pressed={visibleSources[source]}
+            >
+              {source}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {fetchError && <p className="kanban-board__error">{fetchError}</p>}
+
+      <div className="kanban-board__columns">
+        {STAGES.map((stage) => {
+          const stageTasks = columns[stage] || [];
+
+          return (
+            <section key={stage} className="kanban-board__column" aria-label={`${stage} column`}>
+              <header className="kanban-board__column-header">
+                <h2>{stage}</h2>
+                <span className="kanban-board__count">{stageTasks.length}</span>
+              </header>
+
+              <ul className="kanban-board__list">
+                {stageTasks.map((task) => {
+                  const source = getSourceKey(task);
+                  const badgeClass = source.toLowerCase().includes("github")
+                    ? "task-item__badge--github"
+                    : source.toLowerCase().includes("google")
+                      ? "task-item__badge--google"
+                      : source.toLowerCase().includes("trello")
+                        ? "task-item__badge--trello"
+                        : "task-item__badge--default";
+
+                  return (
+                    <li key={task.id} className="kanban-board__card">
+                      <div className="kanban-board__card-meta">
+                        <span className={`task-item__badge ${badgeClass}`}>{source}</span>
+                        {(task.repo || task.pipelineName) && (
+                          <p className="kanban-board__card-subtext">{task.repo || task.pipelineName}</p>
+                        )}
+                      </div>
+                      <p className="kanban-board__card-title">{task.title || task.name}</p>
+                      {task.description && (
+                        <p className="kanban-board__card-description">{task.description}</p>
+                      )}
+                      <label className="kanban-board__stage-label" htmlFor={`stage-${task.id}`}>
+                        Stage
+                      </label>
+                      <select
+                        id={`stage-${task.id}`}
+                        className="kanban-board__stage-select"
+                        value={taskStages[task.id] || "Backlog"}
+                        onChange={(event) => handleStageChange(task.id, event.target.value)}
+                      >
+                        {STAGES.map((option) => (
+                          <option key={option} value={option}>
+                            {option}
+                          </option>
+                        ))}
+                      </select>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+import { useAuth } from "../context/AuthContext";
+
+const NAV_LINKS = [
+  { href: "/", label: "Home", requiresAuth: false },
+  { href: "/dashboard", label: "Dashboard", requiresAuth: true },
+  { href: "/kanban", label: "Kanban Board", requiresAuth: true },
+];
+
+export default function Layout({ children }) {
+  const { user, logout } = useAuth();
+  const router = useRouter();
+
+  const navigationLinks = useMemo(() => {
+    return NAV_LINKS.filter((link) => (link.requiresAuth ? Boolean(user) : true));
+  }, [user]);
+
+  const handleLogout = () => {
+    logout();
+    router.push("/");
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="site-header">
+        <div className="site-header__inner">
+          <Link href="/" className="site-header__brand">
+            My Task Hub
+          </Link>
+
+          <nav className="site-nav" aria-label="Main navigation">
+            {navigationLinks.map((link) => {
+              const isActive = router.pathname === link.href;
+
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={`site-nav__link${isActive ? " site-nav__link--active" : ""}`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          <div className="site-header__actions">
+            {user ? (
+              <>
+                <span className="site-header__user" aria-live="polite">
+                  Hi, {user.name}
+                </span>
+                <button
+                  type="button"
+                  className="button button--ghost site-header__button"
+                  onClick={handleLogout}
+                >
+                  Log out
+                </button>
+              </>
+            ) : (
+              <Link href="/login" className="button button--primary site-header__button">
+                Log in
+              </Link>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <div className="site-content">{children}</div>
+    </div>
+  );
+}

--- a/components/TaskList.js
+++ b/components/TaskList.js
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import { useTasks } from "../hooks/useTasks";
 
 const SOURCE_BADGE_CLASS = {
   GitHub: "github",
@@ -41,9 +42,7 @@ function formatStatus(value) {
 }
 
 export default function TaskList() {
-  const [tasks, setTasks] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [fetchError, setFetchError] = useState("");
+  const { tasks, setTasks, loading, fetchError } = useTasks();
   const [activeTaskId, setActiveTaskId] = useState(null);
   const [completionNote, setCompletionNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -51,122 +50,6 @@ export default function TaskList() {
   const [pipelineStatus, setPipelineStatus] = useState({});
   const [trelloCardStatus, setTrelloCardStatus] = useState({});
   const [trelloComments, setTrelloComments] = useState({});
-
-  const loadTasks = useCallback(
-    async ({ silent = false, signal } = {}) => {
-      if (!silent) {
-        setLoading(true);
-        setFetchError("");
-      }
-
-      try {
-        const requests = [
-          fetch("/api/github", { signal }).then(async (response) => {
-            const data = await response.json().catch(() => null);
-
-            if (!response.ok) {
-              const error = new Error(data?.error || "Failed to load GitHub tasks.");
-              error.status = response.status;
-              throw error;
-            }
-
-            return Array.isArray(data) ? data : [];
-          }),
-          fetch("/api/google-tasks", { signal }).then(async (response) => {
-            const data = await response.json().catch(() => null);
-
-            if (!response.ok) {
-              const error = new Error(data?.error || "Failed to load Google Tasks.");
-              error.status = response.status;
-              throw error;
-            }
-
-            return Array.isArray(data) ? data : [];
-          }),
-          fetch("/api/trello", { signal }).then(async (response) => {
-            const data = await response.json().catch(() => null);
-
-            if (!response.ok) {
-              const error = new Error(data?.error || "Failed to load Trello cards.");
-              error.status = response.status;
-              throw error;
-            }
-
-            return Array.isArray(data) ? data : [];
-          }),
-        ];
-
-        const [githubResult, googleResult, trelloResult] = await Promise.allSettled(requests);
-
-        if (signal?.aborted) {
-          return;
-        }
-
-        const combinedTasks = [];
-        const errors = [];
-
-        if (githubResult.status === "fulfilled") {
-          const githubTasks = githubResult.value.map((task) => ({
-            ...task,
-            id: task.id ?? `github-${task.issue_number}`,
-          }));
-          combinedTasks.push(...githubTasks);
-        } else {
-          errors.push("GitHub tasks");
-          console.error("Failed to load GitHub tasks:", githubResult.reason);
-        }
-
-        if (googleResult.status === "fulfilled") {
-          combinedTasks.push(...googleResult.value);
-        } else {
-          const isConfigError = googleResult.reason?.status === 503;
-          errors.push(isConfigError ? "Google Tasks (integration not configured)" : "Google Tasks");
-          console.error("Failed to load Google Tasks:", googleResult.reason);
-        }
-
-        if (trelloResult.status === "fulfilled") {
-          combinedTasks.push(...trelloResult.value);
-        } else {
-          const isConfigError = trelloResult.reason?.status === 503;
-          errors.push(isConfigError ? "Trello (integration not configured)" : "Trello");
-          console.error("Failed to load Trello cards:", trelloResult.reason);
-        }
-
-        setTasks(combinedTasks);
-
-        if (errors.length === 1) {
-          setFetchError(`Heads up: ${errors[0]} couldn't be loaded right now.`);
-        } else if (errors.length >= 2) {
-          setFetchError("We couldn't load your tasks right now. Please try again.");
-        } else {
-          setFetchError("");
-        }
-      } catch (error) {
-        if (error.name === "AbortError") {
-          return;
-        }
-
-        console.error("Error loading tasks:", error);
-        setTasks([]);
-        setFetchError("We couldn't load your tasks right now. Please try again.");
-      } finally {
-        if (!silent && !signal?.aborted) {
-          setLoading(false);
-        }
-      }
-    },
-    []
-  );
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    loadTasks({ signal: controller.signal });
-
-    return () => {
-      controller.abort();
-    };
-  }, [loadTasks]);
 
   useEffect(() => {
     setTrelloCardStatus((prev) => {

--- a/context/AuthContext.js
+++ b/context/AuthContext.js
@@ -1,0 +1,42 @@
+import { createContext, useContext, useMemo, useState } from "react";
+
+const AuthContext = createContext(undefined);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+
+  const login = (name) => {
+    const trimmedName = name?.trim();
+
+    if (!trimmedName) {
+      return;
+    }
+
+    setUser({ name: trimmedName });
+  };
+
+  const logout = () => {
+    setUser(null);
+  };
+
+  const value = useMemo(
+    () => ({
+      user,
+      login,
+      logout,
+    }),
+    [user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+
+  return context;
+}

--- a/hooks/useTasks.js
+++ b/hooks/useTasks.js
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from "react";
+
+export function useTasks() {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState("");
+
+  const loadTasks = useCallback(
+    async ({ silent = false, signal } = {}) => {
+      if (!silent) {
+        setLoading(true);
+        setFetchError("");
+      }
+
+      try {
+        const requests = [
+          fetch("/api/github", { signal }).then(async (response) => {
+            const data = await response.json().catch(() => null);
+
+            if (!response.ok) {
+              const error = new Error(data?.error || "Failed to load GitHub tasks.");
+              error.status = response.status;
+              throw error;
+            }
+
+            return Array.isArray(data) ? data : [];
+          }),
+          fetch("/api/google-tasks", { signal }).then(async (response) => {
+            const data = await response.json().catch(() => null);
+
+            if (!response.ok) {
+              const error = new Error(data?.error || "Failed to load Google Tasks.");
+              error.status = response.status;
+              throw error;
+            }
+
+            return Array.isArray(data) ? data : [];
+          }),
+          fetch("/api/trello", { signal }).then(async (response) => {
+            const data = await response.json().catch(() => null);
+
+            if (!response.ok) {
+              const error = new Error(data?.error || "Failed to load Trello cards.");
+              error.status = response.status;
+              throw error;
+            }
+
+            return Array.isArray(data) ? data : [];
+          }),
+        ];
+
+        const [githubResult, googleResult, trelloResult] = await Promise.allSettled(requests);
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        const combinedTasks = [];
+        const errors = [];
+
+        if (githubResult.status === "fulfilled") {
+          const githubTasks = githubResult.value.map((task) => ({
+            ...task,
+            id: task.id ?? `github-${task.issue_number}`,
+          }));
+          combinedTasks.push(...githubTasks);
+        } else {
+          errors.push("GitHub tasks");
+          console.error("Failed to load GitHub tasks:", githubResult.reason);
+        }
+
+        if (googleResult.status === "fulfilled") {
+          combinedTasks.push(...googleResult.value);
+        } else {
+          const isConfigError = googleResult.reason?.status === 503;
+          errors.push(isConfigError ? "Google Tasks (integration not configured)" : "Google Tasks");
+          console.error("Failed to load Google Tasks:", googleResult.reason);
+        }
+
+        if (trelloResult.status === "fulfilled") {
+          combinedTasks.push(...trelloResult.value);
+        } else {
+          const isConfigError = trelloResult.reason?.status === 503;
+          errors.push(isConfigError ? "Trello (integration not configured)" : "Trello");
+          console.error("Failed to load Trello cards:", trelloResult.reason);
+        }
+
+        setTasks(combinedTasks);
+
+        if (errors.length === 1) {
+          setFetchError(`Heads up: ${errors[0]} couldn't be loaded right now.`);
+        } else if (errors.length >= 2) {
+          setFetchError("We couldn't load your tasks right now. Please try again.");
+        } else {
+          setFetchError("");
+        }
+      } catch (error) {
+        if (error.name === "AbortError") {
+          return;
+        }
+
+        console.error("Error loading tasks:", error);
+        setTasks([]);
+        setFetchError("We couldn't load your tasks right now. Please try again.");
+      } finally {
+        if (!silent && !signal?.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    loadTasks({ signal: controller.signal });
+
+    return () => {
+      controller.abort();
+    };
+  }, [loadTasks]);
+
+  return { tasks, setTasks, loading, fetchError, reload: loadTasks };
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,13 @@
 import "../styles/globals.css";
+import Layout from "../components/Layout";
+import { AuthProvider } from "../context/AuthContext";
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <AuthProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </AuthProvider>
+  );
 }

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import TaskList from "../components/TaskList";
+import { useAuth } from "../context/AuthContext";
+
+export default function DashboardPage() {
+  const { user } = useAuth();
+
+  if (!user) {
+    return (
+      <main className="restricted">
+        <div className="restricted__card">
+          <h1>Sign in to view your dashboard</h1>
+          <p>
+            You&apos;ll need to log in to see the tasks assigned to you.
+            <Link href="/login"> Log in</Link>
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="dashboard">
+      <section className="dashboard__intro">
+        <h1>Welcome back, {user.name}!</h1>
+        <p>
+          Here&apos;s a quick rundown of everything assigned to you across GitHub, Google Tasks, and
+          Trello.
+        </p>
+      </section>
+      <section className="dashboard__tasks" aria-label="Task rundown">
+        <TaskList />
+      </section>
+    </main>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,22 +1,44 @@
-import TaskList from "../components/TaskList";
+import Link from "next/link";
+import { useAuth } from "../context/AuthContext";
 
 export default function Home() {
+  const { user } = useAuth();
+
   return (
-    <main className="app">
-      <div className="layout">
-        <header className="hero">
-          <span className="hero__eyebrow">Focus. Finish. Ship.</span>
-          <h1>My Task Hub</h1>
-          <p>
-            A polished cockpit for your assigned GitHub issues, Google Tasks, and Trello cards.
-            Scan what needs attention, reshuffle pipelines, add a quick update, and close things
-            out without jumping between tabs.
-          </p>
-        </header>
-        <section className="task-section">
-          <TaskList />
-        </section>
-      </div>
+    <main className="home">
+      <section className="home__hero">
+        <span className="home__eyebrow">Focus. Finish. Ship.</span>
+        <h1 className="home__title">Your unified command center for every task</h1>
+        <p className="home__description">
+          My Task Hub keeps GitHub issues, Google Tasks, and Trello cards at your fingertips.
+          Sign in to see the work waiting for you, then jump into the dashboard or Kanban board
+          to prioritize the next win.
+        </p>
+        <div className="home__actions">
+          {user ? (
+            <>
+              <Link href="/dashboard" className="button button--primary">
+                Go to dashboard
+              </Link>
+              <Link href="/kanban" className="button button--ghost">
+                Open Kanban board
+              </Link>
+            </>
+          ) : (
+            <Link href="/login" className="button button--primary">
+              Log in to get started
+            </Link>
+          )}
+        </div>
+      </section>
+      <section className="home__callout">
+        <h2>What&apos;s inside?</h2>
+        <ul>
+          <li>Real-time dashboard with the tasks assigned to you.</li>
+          <li>Kanban board to shuffle tasks between stages and keep momentum.</li>
+          <li>Filters so you only see the task sources that matter right now.</li>
+        </ul>
+      </section>
     </main>
   );
 }

--- a/pages/kanban.js
+++ b/pages/kanban.js
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import KanbanBoard from "../components/KanbanBoard";
+import { useAuth } from "../context/AuthContext";
+
+export default function KanbanPage() {
+  const { user } = useAuth();
+
+  if (!user) {
+    return (
+      <main className="restricted">
+        <div className="restricted__card">
+          <h1>Sign in to access the Kanban board</h1>
+          <p>
+            Manage your work visually by logging in first.
+            <Link href="/login"> Log in</Link>
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="kanban-page">
+      <header className="kanban-page__intro">
+        <h1>Kanban board</h1>
+        <p>
+          Drag and drop isn&apos;t required—use the stage selector on each task to move it between
+          columns, and filter by task source to focus on the right work.
+        </p>
+      </header>
+      <KanbanBoard />
+    </main>
+  );
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { useAuth } from "../context/AuthContext";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { user, login } = useAuth();
+  const [name, setName] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (user) {
+      router.replace("/dashboard");
+    }
+  }, [router, user]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Please enter your name to continue.");
+      return;
+    }
+
+    login(name);
+    router.push("/dashboard");
+  };
+
+  return (
+    <main className="auth">
+      <form className="auth-card" onSubmit={handleSubmit}>
+        <h1>Log in to My Task Hub</h1>
+        <p>We&apos;ll remember you on this device until you log out.</p>
+
+        <label htmlFor="login-name" className="auth-card__label">
+          Display name
+        </label>
+        <input
+          id="login-name"
+          type="text"
+          className="auth-card__input"
+          value={name}
+          onChange={(event) => {
+            setName(event.target.value);
+            setError("");
+          }}
+          placeholder="Jane Doe"
+          autoComplete="name"
+        />
+        {error && <p className="auth-card__error">{error}</p>}
+
+        <button type="submit" className="button button--primary auth-card__submit">
+          Continue
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -510,3 +510,507 @@ main {
     align-items: stretch;
   }
 }
+
+/* App shell */
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(99, 102, 241, 0.12);
+}
+
+.site-header__inner {
+  margin: 0 auto;
+  width: min(1120px, 100%);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.9rem clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.site-header__brand {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--slate-900);
+  text-decoration: none;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.site-nav__link {
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  color: var(--slate-600);
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.site-nav__link:hover {
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--slate-900);
+}
+
+.site-nav__link--active {
+  background: rgba(99, 102, 241, 0.18);
+  color: var(--accent-strong);
+}
+
+.site-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.site-header__user {
+  font-weight: 600;
+  color: var(--slate-600);
+}
+
+.site-header__button {
+  white-space: nowrap;
+}
+
+.site-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Home */
+.home {
+  flex: 1;
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+  padding: clamp(3rem, 7vw, 5rem) clamp(1.5rem, 5vw, 3.5rem);
+  width: min(1100px, 100%);
+  margin: 0 auto;
+}
+
+.home__hero {
+  display: grid;
+  gap: 1.2rem;
+  max-width: 40rem;
+}
+
+.home__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--accent-strong);
+  opacity: 0.85;
+}
+
+.home__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 3.5rem);
+  line-height: 1.1;
+  color: var(--slate-900);
+}
+
+.home__description {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--slate-600);
+}
+
+.home__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.home__callout {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 28px;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+}
+
+.home__callout h2 {
+  margin: 0 0 1rem 0;
+  color: var(--slate-900);
+}
+
+.home__callout ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--slate-600);
+  display: grid;
+  gap: 0.6rem;
+}
+
+/* Authentication */
+.auth {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(3rem, 6vw, 5rem) clamp(1.5rem, 5vw, 3rem);
+}
+
+.auth-card {
+  width: min(420px, 100%);
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  padding: clamp(2rem, 5vw, 2.75rem);
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow);
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  color: var(--slate-900);
+}
+
+.auth-card p {
+  margin: 0;
+  color: var(--slate-600);
+}
+
+.auth-card__label {
+  font-weight: 600;
+  color: var(--slate-700);
+  font-size: 0.9rem;
+}
+
+.auth-card__input {
+  border-radius: 14px;
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.auth-card__input:focus {
+  outline: none;
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.auth-card__error {
+  margin: 0;
+  color: #dc2626;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.auth-card__submit {
+  margin-top: 0.5rem;
+}
+
+/* Dashboard */
+.dashboard {
+  flex: 1;
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: clamp(3rem, 7vw, 5rem) clamp(1.5rem, 5vw, 3.5rem);
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.dashboard__intro {
+  max-width: 42rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard__intro h1 {
+  margin: 0;
+  color: var(--slate-900);
+}
+
+.dashboard__intro p {
+  margin: 0;
+  color: var(--slate-600);
+}
+
+.dashboard__tasks {
+  display: flex;
+}
+
+/* Restricted access */
+.restricted {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(3rem, 6vw, 5rem);
+}
+
+.restricted__card {
+  width: min(460px, 100%);
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  padding: clamp(2rem, 5vw, 2.75rem);
+  display: grid;
+  gap: 0.9rem;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.restricted__card h1 {
+  margin: 0;
+  color: var(--slate-900);
+}
+
+.restricted__card p {
+  margin: 0;
+  color: var(--slate-600);
+}
+
+.restricted__card a {
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+/* Kanban */
+.kanban-page {
+  flex: 1;
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: clamp(3rem, 7vw, 5rem) clamp(1.5rem, 5vw, 3.5rem);
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.kanban-page__intro {
+  max-width: 46rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.kanban-page__intro h1 {
+  margin: 0;
+  color: var(--slate-900);
+}
+
+.kanban-page__intro p {
+  margin: 0;
+  color: var(--slate-600);
+}
+
+.kanban-board {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.kanban-board--loading,
+.kanban-board--empty {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  padding: clamp(2.5rem, 5vw, 3.5rem);
+  text-align: center;
+  color: var(--slate-600);
+  box-shadow: var(--shadow);
+}
+
+.kanban-board__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.kanban-board__filters-label {
+  font-weight: 600;
+  color: var(--slate-600);
+}
+
+.kanban-board__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.kanban-board__filter {
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--slate-600);
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kanban-board__filter--active {
+  background: rgba(99, 102, 241, 0.14);
+  color: var(--accent-strong);
+  box-shadow: 0 12px 24px -18px rgba(79, 70, 229, 0.5);
+}
+
+.kanban-board__error {
+  margin: 0;
+  color: #b45309;
+  background: rgba(251, 191, 36, 0.14);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  font-weight: 500;
+}
+
+.kanban-board__columns {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 960px) {
+  .kanban-board__columns {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    align-items: flex-start;
+  }
+}
+
+.kanban-board__column {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  border-radius: 22px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+}
+
+.kanban-board__column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.kanban-board__column-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--slate-900);
+}
+
+.kanban-board__count {
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--accent-strong);
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.8rem;
+}
+
+.kanban-board__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.kanban-board__card {
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 18px;
+  border: 1px solid rgba(99, 102, 241, 0.16);
+  padding: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.kanban-board__card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.kanban-board__card-subtext {
+  margin: 0;
+  color: var(--slate-500);
+}
+
+.kanban-board__card-title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--slate-900);
+}
+
+.kanban-board__card-description {
+  margin: 0;
+  color: var(--slate-600);
+  font-size: 0.9rem;
+  white-space: pre-line;
+}
+
+.kanban-board__stage-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--slate-600);
+}
+
+.kanban-board__stage-select {
+  border-radius: 12px;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.kanban-board__stage-select:focus {
+  outline: none;
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+@media (max-width: 720px) {
+  .site-header__inner {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .site-nav {
+    order: 3;
+  }
+
+  .site-header__actions {
+    order: 2;
+  }
+
+  .home {
+    text-align: center;
+    justify-items: center;
+  }
+
+  .home__hero {
+    justify-items: center;
+  }
+
+  .home__callout {
+    text-align: left;
+  }
+
+  .kanban-board__columns {
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- add an authentication context and shared layout with navigation
- split the experience into dedicated home, login, dashboard, and kanban pages
- reuse the task fetching logic across the dashboard list and new Kanban board

## Testing
- CI=1 npx next build

------
https://chatgpt.com/codex/tasks/task_e_68d7e40cfd3083319db88eac7da2fec0