### PR TITLE
Improve kanban board layout responsiveness

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -790,11 +790,13 @@ main {
 /* Kanban */
 .kanban-page {
   flex: 1;
-  width: min(1120px, 100%);
+  width: 100%;
   margin: 0 auto;
   padding: clamp(3rem, 7vw, 5rem) clamp(1.5rem, 5vw, 3.5rem);
   display: grid;
+  grid-template-rows: auto 1fr;
   gap: clamp(2rem, 4vw, 3rem);
+  min-height: 0;
 }
 
 .kanban-page__intro {
@@ -814,8 +816,11 @@ main {
 }
 
 .kanban-board {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
+  flex: 1;
+  min-height: 0;
 }
 
 .kanban-board--loading,
@@ -878,12 +883,14 @@ main {
 .kanban-board__columns {
   display: grid;
   gap: 1.25rem;
+  flex: 1;
+  min-height: 0;
 }
 
 @media (min-width: 960px) {
   .kanban-board__columns {
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    align-items: flex-start;
+    align-items: stretch;
   }
 }
 
@@ -892,10 +899,13 @@ main {
   border: 1px solid rgba(99, 102, 241, 0.12);
   border-radius: 22px;
   padding: 1.25rem;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
   box-shadow: var(--shadow);
   backdrop-filter: blur(10px);
+  min-height: 0;
+  overflow: hidden;
 }
 
 .kanban-board__column-header {
@@ -924,8 +934,20 @@ main {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+@media (max-width: 959px) {
+  .kanban-board__list {
+    overflow: visible;
+    padding-right: 0;
+  }
 }
 
 .kanban-board__card {
@@ -954,6 +976,7 @@ main {
   margin: 0;
   font-weight: 600;
   color: var(--slate-900);
+  word-break: break-word;
 }
 
 .kanban-board__card-description {
@@ -961,6 +984,7 @@ main {
   color: var(--slate-600);
   font-size: 0.9rem;
   white-space: pre-line;
+  word-break: break-word;
 }
 
 .kanban-board__stage-label {


### PR DESCRIPTION
## Summary
- expand the kanban layout to fill the available viewport width
- allow each column to stretch and scroll so cards stay inside their pipeline
- harden card text wrapping to prevent overflow on long content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ea698fd88331a943adda80464f14