### PR TITLE
Fix cursor asset paths for kanban board

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,8 +14,8 @@
   --border-strong: rgba(99, 102, 241, 0.35);
   --card-bg: rgba(255, 255, 255, 0.92);
   --shadow: 0 30px 60px -30px rgba(79, 70, 229, 0.45);
-  --kanban-cursor-idle: url("/public/cursors/kanban-hover.svg") 16 12, grab;
-  --kanban-cursor-active: url("/public/cursors/kanban-drag.svg") 16 12, grabbing;
+  --kanban-cursor-idle: url("/cursors/kanban-hover.svg") 16 12, grab;
+  --kanban-cursor-active: url("/cursors/kanban-drag.svg") 16 12, grabbing;
 }
 
 * {


### PR DESCRIPTION
## Summary
- update the kanban cursor URLs to load from the Next.js public directory so the SVG assets resolve in production

## Testing
- npx next dev --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68d811f3baac8331bf69468b0ae40f2a