### PR TITLE
Prevent importing completed Trello cards and Google Tasks

### DIFF
--- a/pages/api/__tests__/google-tasks.test.js
+++ b/pages/api/__tests__/google-tasks.test.js
@@ -1,0 +1,113 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("does not import tasks from the Completed tasks list", async () => {
+  const originalEnv = {
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+    GOOGLE_REFRESH_TOKEN: process.env.GOOGLE_REFRESH_TOKEN,
+  };
+
+  process.env.GOOGLE_CLIENT_ID = "client";
+  process.env.GOOGLE_CLIENT_SECRET = "secret";
+  process.env.GOOGLE_REFRESH_TOKEN = "refresh";
+
+  const originalFetch = global.fetch;
+  const requests = [];
+
+  global.fetch = async (url, options = {}) => {
+    const urlString = typeof url === "string" ? url : url.toString();
+    requests.push(urlString);
+
+    if (urlString.startsWith("https://oauth2.googleapis.com/token")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "access-token" }),
+      };
+    }
+
+    if (urlString.startsWith("https://tasks.googleapis.com/tasks/v1/users/@me/lists")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: [
+            { id: "list-1", title: "My Tasks" },
+            { id: "list-completed", title: "Completed tasks" },
+          ],
+        }),
+      };
+    }
+
+    if (urlString.includes("/lists/list-1/tasks")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: [
+            {
+              id: "task-1",
+              title: "Draft the launch plan",
+            },
+          ],
+        }),
+      };
+    }
+
+    if (urlString.includes("/lists/list-completed/tasks")) {
+      throw new Error("Should not request tasks for the Completed tasks list");
+    }
+
+    throw new Error(`Unexpected fetch request for ${urlString}`);
+  };
+
+  try {
+    const { default: handler } = await import("../google-tasks.js?skip-completed");
+
+    const req = { method: "GET" };
+    let statusCode = 0;
+    let payload = null;
+
+    const res = {
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json(data) {
+        payload = data;
+        return this;
+      },
+    };
+
+    await handler(req, res);
+
+    assert.equal(statusCode, 200);
+    assert.ok(Array.isArray(payload));
+    assert.equal(payload.length, 1);
+
+    const [task] = payload;
+    assert.equal(task.id, "google-task-1");
+    assert.equal(task.title, "Draft the launch plan");
+    assert.ok(
+      task.pipelineOptions.some((option) => option.id === "list-completed")
+    );
+  } finally {
+    if (originalFetch === undefined) {
+      delete global.fetch;
+    } else {
+      global.fetch = originalFetch;
+    }
+
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+
+  assert.ok(!requests.some((url) => url.includes("list-completed")));
+});
+

--- a/pages/api/__tests__/trello.test.js
+++ b/pages/api/__tests__/trello.test.js
@@ -53,6 +53,43 @@ test("maps Trello cards into task objects", async () => {
   ]);
 });
 
+test("skips cards that already live in a Completed list", async () => {
+  const { mapCardsToTasks } = await import("../trello.js?skip-completed");
+
+  const cards = [
+    {
+      id: "keep-me",
+      name: "Ship the dashboard",
+      idBoard: "board-1",
+      idList: "list-in-progress",
+      list: { name: "In Progress" },
+    },
+    {
+      id: "skip-me",
+      name: "Already done",
+      idBoard: "board-1",
+      idList: "list-completed",
+      list: { name: "Completed" },
+    },
+  ];
+
+  const boardLists = new Map([
+    [
+      "board-1",
+      [
+        { id: "list-in-progress", name: "In Progress" },
+        { id: "list-completed", name: "Completed" },
+      ],
+    ],
+  ]);
+
+  const tasks = mapCardsToTasks(cards, boardLists);
+
+  assert.equal(tasks.length, 1);
+  assert.equal(tasks[0].trelloCardId, "keep-me");
+  assert.equal(tasks[0].pipelineName, "In Progress");
+});
+
 test("maps cards from the fellow board with a Fellow source label", async () => {
   const originalValue = process.env.TRELLO_FELLOW_BOARD_ID;
   process.env.TRELLO_FELLOW_BOARD_ID = "fellow-board";

--- a/pages/api/google-tasks.js
+++ b/pages/api/google-tasks.js
@@ -197,6 +197,12 @@ export default async function handler(req, res) {
 
       const tasksByList = await Promise.all(
         lists.map(async (list) => {
+          const listTitle = typeof list?.title === "string" ? list.title.trim() : "";
+
+          if (listTitle.toLowerCase() === "completed tasks") {
+            return [];
+          }
+
           try {
             const tasks = await fetchTasksForList(accessToken, list.id);
             return tasks.map((task) => mapTaskToResponse(task, list, pipelineOptions));

--- a/pages/api/trello.js
+++ b/pages/api/trello.js
@@ -188,7 +188,32 @@ function mapCardsToTasks(cards, boardLists = new Map()) {
     const title = card.name?.trim() || "Untitled card";
     const description = card.desc?.trim() || "";
     const boardName = card.board?.name?.trim();
-    const listName = card.list?.name?.trim();
+    const boardId = typeof card.idBoard === "string" ? card.idBoard.trim() : "";
+
+    let listName = typeof card.list?.name === "string" ? card.list.name.trim() : "";
+    const cardListId = typeof card.idList === "string" ? card.idList.trim() : "";
+
+    if (!listName && boardId && cardListId) {
+      const listsForBoard = boardLists.get(boardId) || [];
+
+      for (const list of listsForBoard) {
+        const listId = typeof list?.id === "string" ? list.id.trim() : "";
+
+        if (listId && listId === cardListId) {
+          listName = typeof list?.name === "string" ? list.name.trim() : "";
+          if (listName) {
+            break;
+          }
+        }
+      }
+    }
+
+    const normalizedListName = listName.toLowerCase();
+
+    if (normalizedListName === "completed") {
+      continue;
+    }
+
     const due = card.due || null;
 
     let status = "";
@@ -198,7 +223,6 @@ function mapCardsToTasks(cards, boardLists = new Map()) {
       status = "Closed";
     }
 
-    const boardId = typeof card.idBoard === "string" ? card.idBoard.trim() : "";
     const pipelineOptions = boardId
       ? mapListsToOptions(boardLists.get(boardId))
       : [];


### PR DESCRIPTION
## Summary
- skip Trello and Fellow cards that already live in a Completed list when mapping tasks
- avoid importing Google Tasks from the Completed tasks list while keeping it selectable
- cover the new filtering logic with Trello and Google Tasks tests

## Testing
- node --test pages/api/__tests__/*.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8191a9b44833180be70b39b6a2709