### PR TITLE
Add completed task persistence and history merging

### DIFF
--- a/hooks/__tests__/useTasks.test.js
+++ b/hooks/__tests__/useTasks.test.js
@@ -1,0 +1,91 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("mergeTasksWithCompletions marks persisted snapshots as done even when integrations omit them", async () => {
+  const { mergeTasksWithCompletions } = await import("../useTasks.js?test=merge-1");
+  const integrationTasks = [
+    {
+      id: "github-100",
+      source: "GitHub",
+      title: "Fix login bug",
+      repo: "my-org/app",
+      issue_number: 42,
+      url: "https://github.com/my-org/app/issues/42",
+      status: "open",
+    },
+  ];
+
+  const completedSnapshots = [
+    {
+      source: "GitHub",
+      originalId: "my-org/app#42",
+      id: "github-100",
+      title: "Fix login bug",
+      notes: "Closed after deploy",
+      completedAt: "2024-01-10T12:00:00.000Z",
+      status: "Completed locally",
+    },
+    {
+      source: "Trello",
+      originalId: "card-123",
+      id: "trello-card-123",
+      title: "Plan marketing launch",
+      pipelineName: "Done",
+      completedAt: "2024-01-11T08:00:00.000Z",
+    },
+  ];
+
+  const merged = mergeTasksWithCompletions(integrationTasks, completedSnapshots);
+
+  assert.equal(merged.length, 2);
+
+  const githubTask = merged.find((task) => task.source === "GitHub");
+  assert.ok(githubTask, "GitHub task should be present");
+  assert.equal(githubTask.id, "github-100");
+  assert.equal(githubTask.originalId, "my-org/app#42");
+  assert.equal(githubTask.locallyCompleted, true);
+  assert.equal(githubTask.notes, "Closed after deploy");
+  assert.ok(/complete/i.test(githubTask.status));
+  assert.equal(githubTask.url, "https://github.com/my-org/app/issues/42");
+
+  const trelloTask = merged.find((task) => task.source === "Trello");
+  assert.ok(trelloTask, "Trello task should be added from history");
+  assert.equal(trelloTask.locallyCompleted, true);
+  assert.equal(trelloTask.pipelineName, "Done");
+  assert.ok(/complete/i.test(trelloTask.status));
+});
+
+test("mergeTasksWithCompletions keeps integration identifiers while applying completion metadata", async () => {
+  const { mergeTasksWithCompletions } = await import("../useTasks.js?test=merge-2");
+  const integrationTasks = [
+    {
+      id: "trello-abc",
+      source: "Trello",
+      title: "Review analytics dashboard",
+      trelloCardId: "card-abc",
+      pipelineName: "Doing",
+      status: "doing",
+    },
+  ];
+
+  const completedSnapshots = [
+    {
+      source: "Trello",
+      originalId: "card-abc",
+      id: "different-local-id",
+      title: "Review analytics dashboard",
+      pipelineName: "Done",
+      notes: "Moved to done",
+    },
+  ];
+
+  const merged = mergeTasksWithCompletions(integrationTasks, completedSnapshots);
+
+  assert.equal(merged.length, 1);
+  const [card] = merged;
+  assert.equal(card.id, "trello-abc", "Integration identifier should be preserved");
+  assert.equal(card.pipelineName, "Done");
+  assert.equal(card.notes, "Moved to done");
+  assert.equal(card.locallyCompleted, true);
+  assert.ok(/complete/i.test(card.status));
+});

--- a/lib/completedTasksStore.js
+++ b/lib/completedTasksStore.js
@@ -1,0 +1,125 @@
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { buildTaskKey } from "./taskIdentity.js";
+
+const DEFAULT_STORE_FILE = path.join(process.cwd(), "data", "completed-tasks.json");
+
+function getStoreFilePath() {
+  const overridePath = process.env.COMPLETED_TASKS_STORE_PATH;
+  if (overridePath) {
+    return overridePath;
+  }
+
+  return DEFAULT_STORE_FILE;
+}
+
+async function ensureStoreInitialized(filePath) {
+  const directory = path.dirname(filePath);
+  await mkdir(directory, { recursive: true });
+
+  try {
+    await access(filePath);
+  } catch {
+    await writeFile(filePath, "[]", "utf8");
+  }
+}
+
+async function readStore(filePath) {
+  await ensureStoreInitialized(filePath);
+
+  try {
+    const raw = await readFile(filePath, "utf8");
+    const data = JSON.parse(raw);
+
+    if (Array.isArray(data)) {
+      return data;
+    }
+  } catch (error) {
+    console.error("Failed to read completed tasks store:", error);
+  }
+
+  return [];
+}
+
+async function writeStore(filePath, data) {
+  await ensureStoreInitialized(filePath);
+  await writeFile(filePath, JSON.stringify(data, null, 2), "utf8");
+}
+
+function normalizeSnapshot(snapshot = {}) {
+  const normalized = { ...snapshot };
+
+  if (normalized.source) {
+    normalized.source = String(normalized.source);
+  }
+
+  if (normalized.originalId) {
+    normalized.originalId = String(normalized.originalId);
+  }
+
+  if (normalized.notes && typeof normalized.notes !== "string") {
+    normalized.notes = String(normalized.notes);
+  }
+
+  if (normalized.title && typeof normalized.title !== "string") {
+    normalized.title = String(normalized.title);
+  }
+
+  return normalized;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export async function getAllCompletedTasks() {
+  const filePath = getStoreFilePath();
+  const entries = await readStore(filePath);
+  return clone(entries);
+}
+
+export async function upsertCompletedTask(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    throw new Error("A valid completed task snapshot is required.");
+  }
+
+  const normalized = normalizeSnapshot(snapshot);
+  const source = normalized.source;
+  const originalId = normalized.originalId;
+
+  if (!source || !originalId) {
+    throw new Error("Completed task snapshots must include both source and originalId.");
+  }
+
+  const filePath = getStoreFilePath();
+  const entries = await readStore(filePath);
+  const key = buildTaskKey(source, originalId);
+  const now = new Date().toISOString();
+  const fallbackId = normalized.id || `completed-${key.replace(/[^a-zA-Z0-9]/g, "-")}`;
+  const existingIndex = entries.findIndex((entry) => buildTaskKey(entry.source, entry.originalId) === key);
+  const existingEntry = existingIndex >= 0 ? entries[existingIndex] : null;
+
+  const createdAt = existingEntry?.createdAt || normalized.createdAt || now;
+  const completedAt = normalized.completedAt || existingEntry?.completedAt || now;
+
+  const updatedEntry = {
+    ...existingEntry,
+    ...normalized,
+    source,
+    originalId,
+    id: fallbackId,
+    createdAt,
+    completedAt,
+    updatedAt: now,
+  };
+
+  if (existingIndex >= 0) {
+    entries[existingIndex] = updatedEntry;
+  } else {
+    entries.push(updatedEntry);
+  }
+
+  await writeStore(filePath, entries);
+
+  return clone(updatedEntry);
+}

--- a/lib/taskIdentity.js
+++ b/lib/taskIdentity.js
@@ -1,0 +1,83 @@
+export function buildTaskKey(source, originalId) {
+  const normalizedSource = source || "Unknown";
+  const normalizedOriginalId = originalId ?? "";
+  return `${normalizedSource}::${normalizedOriginalId}`;
+}
+
+function stripPrefix(value, prefix) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  if (!value.startsWith(prefix)) {
+    return value;
+  }
+
+  return value.slice(prefix.length);
+}
+
+export function deriveOriginalId(task) {
+  if (!task || typeof task !== "object") {
+    return "";
+  }
+
+  if (task.originalId) {
+    return String(task.originalId);
+  }
+
+  const source = task.source;
+
+  if (source === "GitHub") {
+    if (task.issue_id) {
+      return String(task.issue_id);
+    }
+
+    if (task.issue_number && task.repo) {
+      return `${task.repo}#${task.issue_number}`;
+    }
+
+    if (task.issue_number) {
+      return String(task.issue_number);
+    }
+
+    if (task.id) {
+      return stripPrefix(String(task.id), "github-");
+    }
+  }
+
+  if (source === "Google Tasks") {
+    if (task.googleTaskId) {
+      return String(task.googleTaskId);
+    }
+
+    if (task.id) {
+      return stripPrefix(String(task.id), "google-");
+    }
+  }
+
+  if (source === "Trello") {
+    if (task.trelloCardId) {
+      return String(task.trelloCardId);
+    }
+
+    if (task.id) {
+      return stripPrefix(String(task.id), "trello-");
+    }
+  }
+
+  if (source === "Fellow") {
+    if (task.fellowActionId) {
+      return String(task.fellowActionId);
+    }
+
+    if (task.id) {
+      return stripPrefix(String(task.id), "fellow-");
+    }
+  }
+
+  if (task.id) {
+    return String(task.id);
+  }
+
+  return "";
+}

--- a/pages/api/__tests__/completed-tasks.test.js
+++ b/pages/api/__tests__/completed-tasks.test.js
@@ -1,0 +1,111 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+function createTempStorePath(prefix) {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix)).then((dir) => ({
+    dir,
+    file: path.join(dir, "store.json"),
+  }));
+}
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    end() {
+      return this;
+    },
+  };
+}
+
+test("GET /api/completed-tasks returns an empty list when no snapshots exist", async (t) => {
+  const { dir, file } = await createTempStorePath("completed-store-");
+  process.env.COMPLETED_TASKS_STORE_PATH = file;
+
+  const { default: handler } = await import("../completed-tasks.js?test=get-empty");
+
+  const req = { method: "GET" };
+  const res = createMockResponse();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, []);
+
+  await fs.rm(dir, { recursive: true, force: true });
+  delete process.env.COMPLETED_TASKS_STORE_PATH;
+});
+
+test("POST /api/completed-tasks upserts snapshots by source and originalId", async (t) => {
+  const { dir, file } = await createTempStorePath("completed-store-");
+  process.env.COMPLETED_TASKS_STORE_PATH = file;
+
+  const { default: handler } = await import("../completed-tasks.js?test=upsert");
+
+  const postReq = {
+    method: "POST",
+    body: {
+      source: "GitHub",
+      originalId: "my-org/my-repo#42",
+      id: "github-issue-42",
+      title: "Initial title",
+      notes: "Reviewed",
+    },
+  };
+  const postRes = createMockResponse();
+
+  await handler(postReq, postRes);
+
+  assert.equal(postRes.statusCode, 200);
+  assert.equal(postRes.body.source, "GitHub");
+  assert.equal(postRes.body.originalId, "my-org/my-repo#42");
+  assert.equal(postRes.body.title, "Initial title");
+  assert.ok(postRes.body.updatedAt);
+
+  const updateReq = {
+    method: "POST",
+    body: {
+      source: "GitHub",
+      originalId: "my-org/my-repo#42",
+      id: "github-issue-42",
+      title: "Updated title",
+      notes: "Completed after QA",
+    },
+  };
+  const updateRes = createMockResponse();
+
+  await handler(updateReq, updateRes);
+
+  assert.equal(updateRes.statusCode, 200);
+  assert.equal(updateRes.body.title, "Updated title");
+  assert.equal(updateRes.body.notes, "Completed after QA");
+
+  const getReq = { method: "GET" };
+  const getRes = createMockResponse();
+
+  await handler(getReq, getRes);
+
+  assert.equal(getRes.statusCode, 200);
+  assert.equal(getRes.body.length, 1);
+  const [stored] = getRes.body;
+  assert.equal(stored.title, "Updated title");
+  assert.equal(stored.notes, "Completed after QA");
+
+  await fs.rm(dir, { recursive: true, force: true });
+  delete process.env.COMPLETED_TASKS_STORE_PATH;
+});

--- a/pages/api/completed-tasks.js
+++ b/pages/api/completed-tasks.js
@@ -1,0 +1,34 @@
+import { getAllCompletedTasks, upsertCompletedTask } from "../../lib/completedTasksStore.js";
+
+export default async function handler(req, res) {
+  if (req.method === "GET") {
+    try {
+      const tasks = await getAllCompletedTasks();
+      return res.status(200).json(tasks);
+    } catch (error) {
+      console.error("Failed to load completed tasks:", error);
+      return res.status(500).json({ error: "Failed to load completed tasks." });
+    }
+  }
+
+  if (req.method === "POST") {
+    try {
+      const snapshot = req.body;
+      if (!snapshot || typeof snapshot !== "object") {
+        return res.status(400).json({ error: "A completed task payload is required." });
+      }
+
+      const saved = await upsertCompletedTask(snapshot);
+      return res.status(200).json(saved);
+    } catch (error) {
+      const status = error?.message?.includes("source") || error?.message?.includes("snapshot") ? 400 : 500;
+      console.error("Failed to save completed task:", error);
+      return res
+        .status(status)
+        .json({ error: error?.message || "Failed to save the completed task snapshot." });
+    }
+  }
+
+  res.setHeader("Allow", ["GET", "POST"]);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+}


### PR DESCRIPTION
## Summary
- add a file-backed store for completed tasks and expose a Next.js API endpoint to read/write snapshots
- persist completed task details from the Kanban board and keep locally closed cards in the Done stage
- merge stored completions alongside live integration results and cover the new flows with unit tests

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d83d289f6c83318f6e8962db75c3a6