### PR TITLE
Add Google Calendar views to dashboard

### DIFF
--- a/components/EventList.js
+++ b/components/EventList.js
@@ -1,0 +1,173 @@
+import Link from "next/link";
+import { useMemo } from "react";
+import { useCalendarEvents } from "../hooks/useCalendarEvents";
+
+function formatEventDate(value, { allDay } = {}) {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const options = allDay
+    ? { month: "short", day: "numeric", year: "numeric" }
+    : {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      };
+
+  return new Intl.DateTimeFormat(undefined, options).format(date);
+}
+
+function formatRelativeTime(target) {
+  if (!target) {
+    return "";
+  }
+
+  const now = Date.now();
+  const diffMs = target.getTime() - now;
+
+  if (Number.isNaN(diffMs)) {
+    return "";
+  }
+
+  if (diffMs <= 0) {
+    return "In progress";
+  }
+
+  const diffMinutes = Math.round(diffMs / 60000);
+  if (diffMinutes < 60) {
+    return `In ${diffMinutes} min`;
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  const remainingMinutes = diffMinutes % 60;
+
+  if (diffHours < 24) {
+    return remainingMinutes ? `In ${diffHours}h ${remainingMinutes}m` : `In ${diffHours}h`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+  const remainingHours = diffHours % 24;
+
+  if (diffDays < 7) {
+    if (!remainingHours) {
+      return `In ${diffDays} day${diffDays === 1 ? "" : "s"}`;
+    }
+    return `In ${diffDays}d ${remainingHours}h`;
+  }
+
+  const diffWeeks = Math.floor(diffDays / 7);
+  return `In ${diffWeeks} week${diffWeeks === 1 ? "" : "s"}`;
+}
+
+function EventItem({ event }) {
+  const startDate = event?.start ? new Date(event.start) : null;
+  const countdown = startDate ? formatRelativeTime(startDate) : "";
+  const dateLabel = formatEventDate(event.start, { allDay: event.allDay });
+  const locationLabel = event.location || event.meetingUrl || "";
+
+  return (
+    <li className="event-item">
+      <div className="event-item__header">
+        <p className="event-item__calendar" aria-label="Calendar name">
+          {event.calendarName}
+        </p>
+        {countdown && <span className="event-item__countdown">{countdown}</span>}
+      </div>
+      <h3 className="event-item__title">{event.title}</h3>
+      <dl className="event-item__meta">
+        {dateLabel && (
+          <div>
+            <dt>Date</dt>
+            <dd>{dateLabel}</dd>
+          </div>
+        )}
+        {locationLabel && (
+          <div>
+            <dt>{event.meetingUrl ? "Join" : "Location"}</dt>
+            <dd>
+              {event.meetingUrl ? (
+                <a
+                  href={event.meetingUrl}
+                  className="event-item__link"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  Join meeting
+                </a>
+              ) : (
+                locationLabel
+              )}
+            </dd>
+          </div>
+        )}
+      </dl>
+      {event.description && <p className="event-item__description">{event.description}</p>}
+      {event.htmlLink && (
+        <Link
+          href={event.htmlLink}
+          className="event-item__external"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          View in Google Calendar
+        </Link>
+      )}
+    </li>
+  );
+}
+
+export default function EventList() {
+  const { events, loading, error, nextEvent } = useCalendarEvents({ maxEvents: 8, rangeDays: 21 });
+
+  const eventItems = useMemo(() => events.slice(0, 8), [events]);
+  const nextEventCountdown = useMemo(() => {
+    if (!nextEvent?.start) {
+      return "";
+    }
+    return formatRelativeTime(new Date(nextEvent.start));
+  }, [nextEvent]);
+
+  return (
+    <section className="event-card" aria-label="Upcoming events">
+      <div className="event-card__header">
+        <div>
+          <p className="event-card__eyebrow">Calendar</p>
+          <h2 className="event-card__title">Upcoming meetings</h2>
+        </div>
+        {nextEvent && nextEventCountdown && (
+          <div className="event-card__next">
+            <p className="event-card__next-label">Next event</p>
+            <p className="event-card__next-value">{nextEventCountdown}</p>
+          </div>
+        )}
+      </div>
+
+      {loading && <p className="event-card__status">Loading calendar events…</p>}
+      {error && !loading && <p className="event-card__status event-card__status--error">{error}</p>}
+      {!loading && !error && !eventItems.length && (
+        <p className="event-card__status">No upcoming events found.</p>
+      )}
+
+      {!loading && !error && eventItems.length > 0 && (
+        <ol className="event-card__list">
+          {eventItems.map((event) => (
+            <EventItem key={event.id} event={event} />
+          ))}
+        </ol>
+      )}
+
+      <div className="event-card__footer">
+        <Link href="/calendar" className="event-card__footer-link">
+          View full calendar
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 const NAV_LINKS = [
   { href: "/", label: "Home", requiresAuth: false },
   { href: "/dashboard", label: "Dashboard", requiresAuth: true },
+  { href: "/calendar", label: "Calendar", requiresAuth: true },
   { href: "/kanban", label: "Kanban Board", requiresAuth: true },
 ];
 

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -1,0 +1,27 @@
+# Google Calendar integration
+
+This project can display upcoming events pulled from Google Calendar and show the full calendar embed. To enable it, configure the following environment variables:
+
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REFRESH_TOKEN`: OAuth 2.0 credentials with access to the calendars you want to surface. These are shared with the Google Tasks integration.
+- `GOOGLE_CALENDAR_IDS`: A comma-separated list of calendar IDs to aggregate. Each entry may optionally include a label by appending `:Friendly name` (for example `team@example.com:Team Calendar`).
+- `NEXT_PUBLIC_GOOGLE_CALENDAR_EMBED_URL`: A public embed URL generated from Google Calendar (Settings → Integrate calendar).
+
+## API endpoint
+
+`GET /api/google-calendar`
+
+Retrieves upcoming events and merges them into a single sorted list. The following query parameters are supported:
+
+- `maxResults`: Limits the number of events returned (default: 10).
+- `rangeDays`: Number of days ahead to search for events (default: 30).
+- `timeMin` / `timeMax`: Override the time window manually.
+
+The response consists of simplified event objects including the title, start and end timestamps, description, calendar name, meeting URL, and attendees.
+
+## Dashboard widget
+
+The dashboard consumes the API through the `useCalendarEvents` hook and renders the `EventList` component. It highlights the countdown to the next event and provides quick links to join video calls or open the event in Google Calendar.
+
+## Calendar page
+
+The `/calendar` page shows the embedded calendar inside the app. If the embed URL is not provided, a friendly message explains how to configure it.

--- a/hooks/useCalendarEvents.js
+++ b/hooks/useCalendarEvents.js
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const DEFAULT_MAX_EVENTS = 10;
+const DEFAULT_RANGE_DAYS = 30;
+
+export function useCalendarEvents({ maxEvents = DEFAULT_MAX_EVENTS, rangeDays = DEFAULT_RANGE_DAYS } = {}) {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const loadEvents = useCallback(
+    async ({ silent = false, signal } = {}) => {
+      if (!silent) {
+        setLoading(true);
+        setError("");
+      }
+
+      try {
+        const params = new URLSearchParams();
+        if (maxEvents) {
+          params.set("maxResults", String(maxEvents));
+        }
+        if (rangeDays) {
+          params.set("rangeDays", String(rangeDays));
+        }
+
+        const response = await fetch(`/api/google-calendar?${params.toString()}`, { signal });
+        const data = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          const message = data?.error || "Failed to load Google Calendar events.";
+          const error = new Error(message);
+          error.status = response.status;
+          throw error;
+        }
+
+        setEvents(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (err.name === "AbortError") {
+          return;
+        }
+
+        console.error("Error loading calendar events", err);
+        setError(err.message || "Failed to load Google Calendar events.");
+      } finally {
+        if (!signal?.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    [maxEvents, rangeDays]
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    loadEvents({ signal: controller.signal }).catch(() => {
+      // errors handled in loadEvents
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [loadEvents]);
+
+  const nextEvent = useMemo(() => {
+    if (!events.length) {
+      return null;
+    }
+
+    const now = Date.now();
+    const upcoming = events
+      .map((event) => {
+        const start = event?.start ? new Date(event.start).getTime() : null;
+        if (!start || Number.isNaN(start)) {
+          return null;
+        }
+
+        return { ...event, startTimeMs: start };
+      })
+      .filter((event) => event && event.startTimeMs >= now)
+      .sort((a, b) => a.startTimeMs - b.startTimeMs);
+
+    return upcoming[0] || null;
+  }, [events]);
+
+  return {
+    events,
+    loading,
+    error,
+    refresh: loadEvents,
+    nextEvent,
+  };
+}

--- a/pages/api/google-calendar.js
+++ b/pages/api/google-calendar.js
@@ -1,0 +1,211 @@
+const CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
+const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+const MISSING_CREDENTIALS_ERROR = "MISSING_GOOGLE_CALENDAR_CREDENTIALS";
+
+function parseCalendarConfig(value) {
+  const [idPart, ...labelParts] = value.split(":");
+  const id = idPart?.trim();
+  const label = labelParts.join(":").trim();
+
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    label: label || id,
+  };
+}
+
+function getConfiguredCalendars() {
+  const raw = process.env.GOOGLE_CALENDAR_IDS;
+
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => parseCalendarConfig(value))
+    .filter(Boolean);
+}
+
+function getOAuthConfig() {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    const error = new Error(
+      "Google Calendar integration is not configured. Please provide GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REFRESH_TOKEN environment variables."
+    );
+    error.code = MISSING_CREDENTIALS_ERROR;
+    throw error;
+  }
+
+  return { clientId, clientSecret, refreshToken };
+}
+
+async function getAccessToken() {
+  const { clientId, clientSecret, refreshToken } = getOAuthConfig();
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    const message = data?.error_description || data?.error || "Failed to refresh Google access token.";
+    throw new Error(message);
+  }
+
+  const data = await response.json();
+  const accessToken = data?.access_token;
+
+  if (!accessToken) {
+    throw new Error("Google access token response did not include an access_token.");
+  }
+
+  return accessToken;
+}
+
+function mapEventToResponse(event, calendar) {
+  if (!event || event.status === "cancelled") {
+    return null;
+  }
+
+  const startValue = event.start?.dateTime || event.start?.date || null;
+  const endValue = event.end?.dateTime || event.end?.date || null;
+  const conferenceEntryPoint = Array.isArray(event.conferenceData?.entryPoints)
+    ? event.conferenceData.entryPoints.find((entry) => entry.entryPointType === "video")
+    : null;
+
+  return {
+    id: `${calendar.id}-${event.id}`,
+    eventId: event.id,
+    calendarId: calendar.id,
+    calendarName: calendar.label,
+    title: event.summary || "Untitled event",
+    description: event.description || "",
+    start: startValue,
+    end: endValue,
+    allDay: Boolean(event.start?.date && !event.start?.dateTime),
+    location: event.location || null,
+    meetingUrl: conferenceEntryPoint?.uri || event.hangoutLink || null,
+    htmlLink: event.htmlLink || null,
+    attendees: Array.isArray(event.attendees)
+      ? event.attendees.map((attendee) => ({
+          email: attendee.email,
+          displayName: attendee.displayName || attendee.email || null,
+          responseStatus: attendee.responseStatus || null,
+        }))
+      : [],
+  };
+}
+
+async function fetchEventsForCalendar(accessToken, calendar, { timeMin, timeMax, maxResults }) {
+  const events = [];
+  let pageToken;
+
+  do {
+    const url = new URL(`${CALENDAR_BASE_URL}/calendars/${encodeURIComponent(calendar.id)}/events`);
+    url.searchParams.set("singleEvents", "true");
+    url.searchParams.set("orderBy", "startTime");
+    url.searchParams.set("timeMin", timeMin);
+    if (timeMax) {
+      url.searchParams.set("timeMax", timeMax);
+    }
+    if (maxResults) {
+      url.searchParams.set("maxResults", String(maxResults));
+    }
+    if (pageToken) {
+      url.searchParams.set("pageToken", pageToken);
+    }
+
+    const response = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      const message = data?.error?.message || `Failed to retrieve events for Google Calendar ${calendar.id}.`;
+      throw new Error(message);
+    }
+
+    const data = await response.json();
+    if (Array.isArray(data.items)) {
+      events.push(
+        ...data.items
+          .map((event) => mapEventToResponse(event, calendar))
+          .filter(Boolean)
+      );
+    }
+    pageToken = data.nextPageToken;
+
+    if (maxResults && events.length >= maxResults) {
+      break;
+    }
+  } while (pageToken);
+
+  return events;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", ["GET"]);
+    return res.status(405).json({ error: "Method not allowed." });
+  }
+
+  const calendars = getConfiguredCalendars();
+  if (!calendars.length) {
+    return res.status(200).json([]);
+  }
+
+  const maxResults = Number.parseInt(req.query.maxResults, 10);
+  const safeMaxResults = Number.isNaN(maxResults) || maxResults <= 0 ? undefined : maxResults;
+  const rangeDays = Number.parseInt(req.query.rangeDays, 10);
+  const effectiveRangeDays = Number.isNaN(rangeDays) || rangeDays <= 0 ? 30 : rangeDays;
+
+  const now = new Date();
+  const timeMin = req.query.timeMin || now.toISOString();
+  const timeMax = req.query.timeMax || new Date(now.getTime() + effectiveRangeDays * 24 * 60 * 60 * 1000).toISOString();
+
+  try {
+    const accessToken = await getAccessToken();
+    const eventsByCalendar = await Promise.all(
+      calendars.map((calendar) => fetchEventsForCalendar(accessToken, calendar, { timeMin, timeMax, maxResults: safeMaxResults }))
+    );
+
+    const events = eventsByCalendar.flat();
+    events.sort((a, b) => {
+      const aTime = a.start ? new Date(a.start).getTime() : Number.POSITIVE_INFINITY;
+      const bTime = b.start ? new Date(b.start).getTime() : Number.POSITIVE_INFINITY;
+      return aTime - bTime;
+    });
+
+    if (safeMaxResults) {
+      return res.status(200).json(events.slice(0, safeMaxResults));
+    }
+
+    return res.status(200).json(events);
+  } catch (error) {
+    if (error.code === MISSING_CREDENTIALS_ERROR) {
+      return res.status(501).json({ error: error.message, code: error.code });
+    }
+
+    console.error("Error loading Google Calendar events", error);
+    return res.status(500).json({ error: error.message || "Failed to load Google Calendar events." });
+  }
+}

--- a/pages/calendar.js
+++ b/pages/calendar.js
@@ -1,0 +1,50 @@
+import { SignedIn, SignedOut } from "@clerk/nextjs";
+import Link from "next/link";
+
+const embedUrl = process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_EMBED_URL;
+
+export default function CalendarPage() {
+  return (
+    <>
+      <SignedOut>
+        <main className="restricted">
+          <div className="restricted__card">
+            <h1>Sign in to view the calendar</h1>
+            <p>
+              You&apos;ll need to log in to view the team&apos;s schedule.
+              <Link href="/login"> Log in</Link>
+            </p>
+          </div>
+        </main>
+      </SignedOut>
+
+      <SignedIn>
+        <main className="calendar-page">
+          <header className="calendar-page__header">
+            <p className="calendar-page__eyebrow">Calendar</p>
+            <h1>Team schedule</h1>
+            <p>Review the complete Google Calendar for upcoming meetings, deadlines, and events.</p>
+          </header>
+
+          <section className="calendar-page__embed" aria-label="Embedded Google Calendar">
+            {embedUrl ? (
+              <iframe
+                title="Google Calendar"
+                src={embedUrl}
+                className="calendar-page__iframe"
+                frameBorder="0"
+                scrolling="no"
+              />
+            ) : (
+              <div className="calendar-page__placeholder">
+                <p>
+                  Add a public embed URL to <code>NEXT_PUBLIC_GOOGLE_CALENDAR_EMBED_URL</code> to display the calendar here.
+                </p>
+              </div>
+            )}
+          </section>
+        </main>
+      </SignedIn>
+    </>
+  );
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,6 +1,7 @@
 import { SignedIn, SignedOut, useUser } from "@clerk/nextjs";
 import Link from "next/link";
 import { useMemo } from "react";
+import EventList from "../components/EventList";
 import TaskList from "../components/TaskList";
 
 export default function DashboardPage() {
@@ -42,9 +43,14 @@ export default function DashboardPage() {
               Trello.
             </p>
           </section>
-          <section className="dashboard__tasks" aria-label="Task rundown">
-            <TaskList />
-          </section>
+          <div className="dashboard__columns">
+            <section className="dashboard__tasks" aria-label="Task rundown">
+              <TaskList />
+            </section>
+            <section className="dashboard__events" aria-label="Calendar rundown">
+              <EventList />
+            </section>
+          </div>
         </main>
       </SignedIn>
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -764,6 +764,268 @@ main {
   display: flex;
 }
 
+.dashboard__columns {
+  display: grid;
+  gap: clamp(2rem, 4vw, 2.5rem);
+}
+
+.dashboard__events {
+  display: flex;
+}
+
+@media (min-width: 1040px) {
+  .dashboard__columns {
+    grid-template-columns: 1.35fr 1fr;
+    align-items: start;
+  }
+}
+
+.event-card {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: clamp(20px, 4vw, 26px);
+  border: 1px solid var(--border);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+}
+
+.event-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.event-card__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-strong);
+  opacity: 0.85;
+  margin: 0 0 0.25rem;
+}
+
+.event-card__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 1.2vw + 1.2rem, 1.8rem);
+  color: var(--slate-900);
+}
+
+.event-card__next {
+  padding: 0.85rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(99, 102, 241, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.24);
+  display: grid;
+  gap: 0.3rem;
+  min-width: 150px;
+}
+
+.event-card__next-label {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  letter-spacing: 0.15em;
+}
+
+.event-card__next-value {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--slate-900);
+}
+
+.event-card__status {
+  margin: 0;
+  color: var(--slate-600);
+  font-size: 0.95rem;
+}
+
+.event-card__status--error {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.event-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.event-item {
+  border-radius: 18px;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  padding: clamp(1.1rem, 3vw, 1.5rem);
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.event-item__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.event-item__calendar {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-strong);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.event-item__countdown {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--slate-600);
+}
+
+.event-item__title {
+  margin: 0;
+  font-size: clamp(1.05rem, 0.9vw + 0.9rem, 1.3rem);
+  color: var(--slate-900);
+}
+
+.event-item__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.event-item__meta dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: var(--slate-500);
+}
+
+.event-item__meta dd {
+  margin: 0.3rem 0 0;
+  color: var(--slate-700);
+  font-weight: 500;
+}
+
+.event-item__description {
+  margin: 0;
+  color: var(--slate-600);
+  font-size: 0.95rem;
+}
+
+.event-item__external,
+.event-item__link,
+.event-card__footer-link {
+  color: var(--accent-strong);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.event-item__external:hover,
+.event-item__link:hover,
+.event-card__footer-link:hover {
+  text-decoration: underline;
+}
+
+.event-card__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.event-card__footer-link {
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .event-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .event-card__next {
+    width: 100%;
+  }
+}
+
+.calendar-page {
+  flex: 1;
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: clamp(3rem, 7vw, 5rem) clamp(1.5rem, 5vw, 3.5rem);
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.calendar-page__header {
+  max-width: 42rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.calendar-page__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.calendar-page__header h1 {
+  margin: 0;
+  color: var(--slate-900);
+}
+
+.calendar-page__header p {
+  margin: 0;
+  color: var(--slate-600);
+}
+
+.calendar-page__embed {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: clamp(20px, 4vw, 28px);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  min-height: 600px;
+}
+
+.calendar-page__iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  min-height: 600px;
+}
+
+.calendar-page__placeholder {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  padding: clamp(2rem, 5vw, 3rem);
+  color: var(--slate-600);
+  text-align: center;
+}
+
+.calendar-page__placeholder code {
+  font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 12px;
+  padding: 0.2rem 0.5rem;
+  color: var(--accent-strong);
+}
+
 /* Restricted access */
 .restricted {
   flex: 1;


### PR DESCRIPTION
## Summary
- add a Google Calendar API route plus a reusable hook and event list component for upcoming meetings
- update the dashboard layout to include the calendar rundown with a countdown to the next event
- add a dedicated calendar page with embed support and document the required environment variables

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dab6ff23708331a07ba37e411c5cd7