### PR TITLE
Fix completed tasks storage path on read-only deployments

### DIFF
--- a/lib/completedTasksStore.js
+++ b/lib/completedTasksStore.js
@@ -1,8 +1,13 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { buildTaskKey } from "./taskIdentity.js";
 
-const DEFAULT_STORE_FILE = path.join(process.cwd(), "data", "completed-tasks.json");
+const DEFAULT_STORE_FILE = path.join(
+  tmpdir(),
+  "my-task-hub",
+  "completed-tasks.json",
+);
 
 function getStoreFilePath() {
   const overridePath = process.env.COMPLETED_TASKS_STORE_PATH;


### PR DESCRIPTION
## Summary
- default completed tasks JSON storage to the OS temporary directory so it can be created on read-only deployments
- keep support for overriding the storage path via COMPLETED_TASKS_STORE_PATH

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dae4ac13948331a1d2d4ebe409e2f5