### PR TITLE
Make sidebar collapsible overlay on all screen sizes

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4804,7 +4804,6 @@ body.menu-open {
   width: 280px;
   background: white;
   border-right: 1px solid var(--border);
-  box-shadow: 4px 0 20px rgba(0, 0, 0, 0.08);
   z-index: 99;
   display: flex;
   flex-direction: column;
@@ -4912,38 +4911,18 @@ body.menu-open {
 /* Main Content Area */
 .site-content {
   margin-top: 60px;
-  transition: margin-left 0.3s ease;
+  transition: none;
   width: 100%;
   max-width: 100vw;
 }
 
-/* Desktop: Sidebar Always Visible */
-@media (min-width: 1024px) {
-  .sidebar {
-    transform: translateX(0);
-  }
-
-  .sidebar-backdrop {
-    display: none;
-  }
-
-  .site-header {
-    left: 280px;
-    width: calc(100% - 280px);
-  }
-
-  .site-content {
-    margin-left: 280px;
-    max-width: calc(100vw - 280px);
-  }
+/* Sidebar Overlay - All Screen Sizes */
+.sidebar {
+  box-shadow: 4px 0 30px rgba(0, 0, 0, 0.15);
 }
 
-/* Mobile: Sidebar Overlay */
+/* Mobile: Hide user name to save space */
 @media (max-width: 1023px) {
-  .sidebar {
-    box-shadow: 4px 0 30px rgba(0, 0, 0, 0.15);
-  }
-
   .site-header__user {
     display: none;
   }
@@ -5085,7 +5064,7 @@ body.menu-open {
 
 @media (min-width: 1024px) {
   .focus-mode {
-    width: calc(100vw - 280px);
+    width: 100vw;
     margin-left: 0 !important;
     left: 0;
     right: 0;


### PR DESCRIPTION
Changes:
- Sidebar now overlays content instead of pushing it aside
- Sidebar can be collapsed on all screen sizes including ultra-wide
- Removes content shift - page content stays fixed when sidebar opens/closes
- Header spans full width at all times (no left offset)
- Consistent sidebar behavior across mobile, tablet, desktop, and ultra-wide

Technical details:
- Remove desktop auto-show: sidebar always starts hidden (transform: translateX(-100%))
- Remove margin-left shift from .site-content on desktop
- Remove left offset and width calc from .site-header on desktop
- Backdrop now shows on all screen sizes when sidebar is open
- Focus mode width: 100vw (was calc(100vw - 280px))
- Remove transition from site-content (no shifting animation needed)

This fixes the issue where content was being pushed off the right side of the screen when the sidebar was open, especially on ultra-wide displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)